### PR TITLE
CO SOS data: elections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,6 +3607,7 @@ dependencies = [
 name = "scrapers"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "csv",
  "db",
  "project-root",

--- a/scrapers/Cargo.toml
+++ b/scrapers/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 db = { path = "../db" }
+chrono = "0"
 csv = "1"
 project-root = "0"
 regex = "1"

--- a/scrapers/src/extractors/office.rs
+++ b/scrapers/src/extractors/office.rs
@@ -6,7 +6,6 @@ use regex::Regex;
 pub struct OfficeMeta {
     pub name: String,
     pub title: String,
-    pub r#type: Option<String>, // TODO - What determines this?
     pub chamber: Option<db::Chamber>,
     pub district_type: Option<db::DistrictType>,
     pub political_scope: db::PoliticalScope,
@@ -23,7 +22,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "U.S. Senate".into(),
                     title: "U.S. Senator".into(),
-                    r#type: None,
                     chamber: Some(db::Chamber::Senate),
                     district_type: None,
                     political_scope: db::PoliticalScope::Federal,
@@ -35,7 +33,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "U.S. House".into(),
                     title: "U.S. Representative".into(),
-                    r#type: None,
                     chamber: Some(db::Chamber::House),
                     district_type: Some(db::DistrictType::UsCongressional),
                     political_scope: db::PoliticalScope::Federal,
@@ -47,7 +44,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "State Senate".into(),
                     title: "State Senator".into(),
-                    r#type: None,
                     chamber: Some(db::Chamber::Senate),
                     district_type: Some(db::DistrictType::StateHouse),
                     political_scope: db::PoliticalScope::State,
@@ -59,7 +55,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "State House".into(),
                     title: "State Representative".into(),
-                    r#type: None,
                     chamber: Some(db::Chamber::House),
                     district_type: Some(db::DistrictType::StateHouse),
                     political_scope: db::PoliticalScope::State,
@@ -71,7 +66,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "Board of Education".into(),
                     title: "Board of Education Member".into(),
-                    r#type: None,
                     chamber: None,
                     district_type: Some(db::DistrictType::School),
                     political_scope: db::PoliticalScope::State,
@@ -83,7 +77,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "Board of Regents".into(),
                     title: "Regent".into(),
-                    r#type: None,
                     chamber: None,
                     district_type: Some(db::DistrictType::School),
                     political_scope: db::PoliticalScope::State,
@@ -95,7 +88,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "District Attorney".into(),
                     title: "District Attorney".into(),
-                    r#type: None,
                     chamber: None,
                     district_type: Some(db::DistrictType::Judicial),
                     political_scope: db::PoliticalScope::State,
@@ -107,7 +99,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "District Court Judge".into(),
                     title: "District Court Judge".into(),
-                    r#type: None,
                     chamber: None,
                     district_type: Some(db::DistrictType::Judicial),
                     political_scope: db::PoliticalScope::State,
@@ -119,7 +110,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "County Court Judge".into(),
                     title: "County Court Judge".into(),
-                    r#type: None,
                     chamber: None,
                     district_type: None,
                     political_scope: db::PoliticalScope::State,
@@ -131,7 +121,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "Court of Appeals Judge".into(),
                     title: "Court of Appeals Judge".into(),
-                    r#type: None,
                     chamber: None,
                     district_type: None,
                     political_scope: db::PoliticalScope::State,
@@ -143,7 +132,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "Supreme Court Justice".into(),
                     title: "Supreme Court Justice".into(),
-                    r#type: None,
                     chamber: None,
                     district_type: None,
                     political_scope: db::PoliticalScope::State,
@@ -155,7 +143,6 @@ pub fn extract_office_meta(input: &str) -> Option<OfficeMeta> {
                 OfficeMeta {
                     name: "Regional Transportation District Director".into(),
                     title: "Regional Transportation District Director".into(),
-                    r#type: None,
                     chamber: None,
                     district_type: None, // TODO - Add a "transportation" district type ???
                     political_scope: db::PoliticalScope::State,

--- a/scrapers/src/lib.rs
+++ b/scrapers/src/lib.rs
@@ -3,8 +3,6 @@ use std::{error::Error, future::Future};
 use chrono::{Days, NaiveDate, Weekday};
 use slugify::slugify;
 
-use db::FullState;
-
 pub mod extractors;
 pub mod mn_sos_candidate_filings_fed_state_county;
 pub mod mn_sos_candidate_filings_local;
@@ -41,8 +39,8 @@ pub fn generate_general_election_date(year: u16) -> Result<NaiveDate, Box<dyn Er
     Ok(next_tuesday)
 }
 
-pub fn generate_general_election_title_slug(state: &db::State, year: u16) -> (String, String) {
-    let title = format!("{} General Election {year}", state.full_state());
+pub fn generate_general_election_title_slug(year: u16) -> (String, String) {
+    let title = format!("General Election {year}");
     let slug = slugify!(&title);
     (title, slug)
 }
@@ -95,25 +93,13 @@ mod tests {
 
     #[test]
     fn generate_general_election_title_slug() {
-        let tests: Vec<((&'static str, &'static str), (db::State, u16))> = vec![
-            (
-                (
-                    "Colorado General Election 2024",
-                    "colorado-general-election-2024",
-                ),
-                (db::State::CO, 2024),
-            ),
-            (
-                (
-                    "Minnesota General Election 2025",
-                    "minnesota-general-election-2025",
-                ),
-                (db::State::MN, 2025),
-            ),
+        let tests: Vec<((&'static str, &'static str), u16)> = vec![
+            (("General Election 2024", "general-election-2024"), 2024),
+            (("General Election 2025", "general-election-2025"), 2025),
         ];
 
         for (expected, input) in tests {
-            let actual = super::generate_general_election_title_slug(&input.0, input.1);
+            let actual = super::generate_general_election_title_slug(input);
             assert_eq!(expected.0, actual.0);
             assert_eq!(expected.1, actual.1);
         }

--- a/scrapers/src/lib.rs
+++ b/scrapers/src/lib.rs
@@ -1,6 +1,9 @@
 use std::{error::Error, future::Future};
 
+use chrono::{Days, NaiveDate, Weekday};
 use slugify::slugify;
+
+use db::FullState;
 
 pub mod extractors;
 pub mod mn_sos_candidate_filings_fed_state_county;
@@ -25,6 +28,23 @@ pub trait Scraper {
         &self,
         context: &ScraperContext,
     ) -> impl Future<Output = Result<(), Box<dyn Error>>> + Send;
+}
+
+// Reference: https://en.wikipedia.org/wiki/Election_Day_(United_States)
+// "The Tuesday after the first Monday of November"
+pub fn generate_general_election_date(year: u16) -> Result<NaiveDate, Box<dyn Error>> {
+    let first_monday = NaiveDate::from_weekday_of_month_opt(year as _, 11, Weekday::Mon, 1)
+        .ok_or_else(|| format!("Unable to determine general election date for year: {year}"))?;
+    let next_tuesday = first_monday
+        .checked_add_days(Days::new(1))
+        .ok_or_else(|| format!("Unable to determine general election date for year: {year}"))?;
+    Ok(next_tuesday)
+}
+
+pub fn generate_general_election_title_slug(state: &db::State, year: u16) -> (String, String) {
+    let title = format!("{} General Election {year}", state.full_state());
+    let slug = slugify!(&title);
+    (title, slug)
 }
 
 pub fn generate_office_slug(input: &db::UpsertOfficeInput) -> String {
@@ -54,6 +74,51 @@ pub fn generate_office_slug(input: &db::UpsertOfficeInput) -> String {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Datelike;
+
+    #[test]
+    fn generate_general_election_date() {
+        let tests: Vec<((u32, u32), u16)> = vec![
+            ((11, 7), 2023),
+            ((11, 5), 2024),
+            ((11, 4), 2025),
+            ((11, 3), 2026),
+            ((11, 2), 2027),
+            ((11, 7), 2028),
+        ];
+
+        for (expected, input) in tests {
+            let date = super::generate_general_election_date(input).unwrap();
+            assert_eq!(expected, (date.month(), date.day()));
+        }
+    }
+
+    #[test]
+    fn generate_general_election_title_slug() {
+        let tests: Vec<((&'static str, &'static str), (db::State, u16))> = vec![
+            (
+                (
+                    "Colorado General Election 2024",
+                    "colorado-general-election-2024",
+                ),
+                (db::State::CO, 2024),
+            ),
+            (
+                (
+                    "Minnesota General Election 2025",
+                    "minnesota-general-election-2025",
+                ),
+                (db::State::MN, 2025),
+            ),
+        ];
+
+        for (expected, input) in tests {
+            let actual = super::generate_general_election_title_slug(&input.0, input.1);
+            assert_eq!(expected.0, actual.0);
+            assert_eq!(expected.1, actual.1);
+        }
+    }
+
     #[test]
     fn generate_office_slug() {
         let tests: Vec<(&'static str, db::UpsertOfficeInput)> = vec![

--- a/scrapers/src/scrapers/co/sos/general_candidates.rs
+++ b/scrapers/src/scrapers/co/sos/general_candidates.rs
@@ -1,5 +1,6 @@
-use std::error::Error;
+use std::{error::Error, sync::OnceLock};
 
+use regex::Regex;
 use scraper::{Html, Selector};
 
 use crate::{extractors::*, util, util::extensions::NoneIfEmptyExt};
@@ -28,11 +29,29 @@ impl Scraper {
         html: String,
         context: &crate::ScraperContext<'_>,
     ) -> Result<(), Box<dyn Error>> {
-        let entries = Self::parse_raw_entries(html)?;
-        for entry in entries {
-            let mut office = Self::build_office_input(&entry);
-            office.slug = Some(crate::generate_office_slug(&office));
-            if let Err(err) = db::Office::upsert_from_source(&context.db.connection, &office).await
+        let data = Self::scrape_page_data(html)?;
+
+        let election_year = Self::parse_election_year(&data.title)?;
+        let election_date = crate::generate_general_election_date(election_year)?;
+        let (election_title, election_slug) =
+            crate::generate_general_election_title_slug(&db::State::CO, election_year);
+        let _election = db::Election::upsert_from_source(
+            &context.db.connection,
+            &db::UpsertElectionInput {
+                slug: Some(election_slug),
+                title: Some(election_title),
+                state: Some(db::State::CO),
+                election_date: Some(election_date),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        for entry in data.candidates {
+            let mut office_input = Self::build_office_input(&entry);
+            office_input.slug = Some(crate::generate_office_slug(&office_input));
+            if let Err(err) =
+                db::Office::upsert_from_source(&context.db.connection, &office_input).await
             {
                 // TODO - Track/log error
                 panic!("{err}");
@@ -41,10 +60,27 @@ impl Scraper {
         Ok(())
     }
 
-    pub fn parse_raw_entries(html: String) -> Result<Vec<RawEntry>, Box<dyn Error>> {
+    pub fn scrape_page_data(html: String) -> Result<PageData, Box<dyn Error>> {
+        let html = Html::parse_document(&html);
+        Ok(PageData {
+            title: Self::scrape_page_title(&html)?,
+            candidates: Self::scrape_candidate_entries(&html)?,
+        })
+    }
+
+    pub fn scrape_page_title(html: &Html) -> Result<String, Box<dyn Error>> {
+        let title = html
+            .select(&Selector::parse("p.pageTitle")?)
+            .next()
+            .ok_or("Page title not found")?
+            .text()
+            .collect::<String>();
+        Ok(title)
+    }
+
+    pub fn scrape_candidate_entries(html: &Html) -> Result<Vec<CandidateEntry>, Box<dyn Error>> {
         let mut entries = Vec::new();
-        let document = Html::parse_document(&html);
-        for (index, element) in document
+        for (index, element) in html
             .select(&Selector::parse("table.w3-cmsTable")?)
             .next()
             .ok_or("Candidate table not found")?
@@ -67,7 +103,7 @@ impl Scraper {
                     .map(|f| f.none_if_empty())
             };
 
-            let entry = RawEntry {
+            let entry = CandidateEntry {
                 index,
                 name: next_field("name")?.ok_or("Empty name field")?,
                 office: next_field("office")?.ok_or("Empty office field")?,
@@ -83,7 +119,20 @@ impl Scraper {
         Ok(entries)
     }
 
-    fn build_office_input(entry: &RawEntry) -> db::UpsertOfficeInput {
+    pub fn parse_election_year(title: &str) -> Result<u16, Box<dyn Error>> {
+        static REGEX: OnceLock<Regex> = OnceLock::new();
+        let regex = REGEX.get_or_init(|| Regex::new(r"(\d{4}) General Election").unwrap());
+        let year = regex
+            .captures(title)
+            .ok_or("Unexpected election title format")?
+            .get(1)
+            .ok_or("Failure extracting election year from title")?
+            .as_str()
+            .parse::<u16>()?;
+        Ok(year)
+    }
+
+    fn build_office_input(entry: &CandidateEntry) -> db::UpsertOfficeInput {
         let Some(meta) = extract_office_meta(&entry.office) else {
             // TODO - Track/log failed scrape
             return db::UpsertOfficeInput::default();
@@ -124,7 +173,12 @@ impl Scraper {
     }
 }
 
-pub struct RawEntry {
+pub struct PageData {
+    pub title: String,
+    pub candidates: Vec<CandidateEntry>,
+}
+
+pub struct CandidateEntry {
     pub index: usize,
     pub name: String,
     pub office: String,

--- a/scrapers/src/scrapers/co/sos/general_candidates.rs
+++ b/scrapers/src/scrapers/co/sos/general_candidates.rs
@@ -34,13 +34,12 @@ impl Scraper {
         let election_year = Self::parse_election_year(&data.title)?;
         let election_date = crate::generate_general_election_date(election_year)?;
         let (election_title, election_slug) =
-            crate::generate_general_election_title_slug(&db::State::CO, election_year);
+            crate::generate_general_election_title_slug(election_year);
         let _election = db::Election::upsert_from_source(
             &context.db.connection,
             &db::UpsertElectionInput {
                 slug: Some(election_slug),
                 title: Some(election_title),
-                state: Some(db::State::CO),
                 election_date: Some(election_date),
                 ..Default::default()
             },


### PR DESCRIPTION
Adds Colorado Secretary of State General Election election data.

You can test this locally by running the following commands:

```bash
$ cd scrapers/
$ cargo run --bin co_sos_general_candidates
```

The `election` data will be inserted into the database associated with the `DATABASE_URL` environment variable in your `.env` file.