### PR TITLE
CO SOS data: parties

### DIFF
--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -19,6 +19,7 @@ pub use models::issue_tag::*;
 pub use models::office::*;
 pub use models::organization::*;
 pub use models::organization_politician_note::*;
+pub use models::party::*;
 pub use models::politician::*;
 pub use models::poll::*;
 pub use models::question::*;

--- a/db/src/models/mod.rs
+++ b/db/src/models/mod.rs
@@ -11,6 +11,7 @@ pub mod issue_tag;
 pub mod office;
 pub mod organization;
 pub mod organization_politician_note;
+pub mod party;
 pub mod politician;
 pub mod poll;
 pub mod question;

--- a/db/src/models/party.rs
+++ b/db/src/models/party.rs
@@ -1,0 +1,58 @@
+use async_graphql::InputObject;
+use sqlx::postgres::PgPool;
+use sqlx::FromRow;
+
+#[derive(FromRow, Debug, Clone)]
+pub struct Party {
+    pub id: uuid::Uuid,
+    pub slug: String,
+    pub name: String,
+    pub fec_code: Option<String>,
+    pub description: Option<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(InputObject, Default, Debug)]
+pub struct UpsertPartyInput {
+    pub id: Option<uuid::Uuid>,
+    pub slug: Option<String>,
+    pub name: Option<String>,
+    pub fec_code: Option<String>,
+    pub description: Option<String>,
+    pub notes: Option<String>,
+}
+
+impl Party {
+    pub async fn upsert_from_source(
+        db_pool: &PgPool,
+        input: &UpsertPartyInput,
+    ) -> Result<Self, sqlx::Error> {
+        input
+            .slug
+            .as_ref()
+            .ok_or("slug is required")
+            .map_err(|err| sqlx::Error::AnyDriverError(err.into()))?;
+
+        sqlx::query_as!(
+            Party,
+            r#"
+                INSERT INTO party
+                (slug, name, description, fec_code, notes)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (slug) DO UPDATE SET
+                    name = COALESCE($2, party.name),
+                    description = COALESCE($3, party.description),
+                    fec_code = COALESCE($4, party.fec_code),
+                    notes = COALESCE($5, party.notes)
+                RETURNING id, slug, name, description, fec_code, notes
+            "#,
+            input.slug,
+            input.name,
+            input.description,
+            input.fec_code,
+            input.notes,
+        )
+        .fetch_one(db_pool)
+        .await
+    }
+}

--- a/scrapers/src/extractors/mod.rs
+++ b/scrapers/src/extractors/mod.rs
@@ -1,3 +1,5 @@
 mod office;
+mod party;
 
 pub use office::*;
+pub use party::*;

--- a/scrapers/src/extractors/party.rs
+++ b/scrapers/src/extractors/party.rs
@@ -1,0 +1,85 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+static MATCHERS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
+
+pub fn extract_party_name(input: &str) -> Option<String> {
+    let matchers = MATCHERS.get_or_init(|| {
+        [
+            (
+                r"(?i:(?:Unaffiliated|No Party Affiliation))",
+                "Unaffiliated",
+            ),
+            (r"(?i:Democratic Party)", "Democratic Party"),
+            (r"(?i:Republican Party)", "Republican Party"),
+            (r"(?i:Libertarian Party)", "Libertarian Party"),
+            (
+                r"(?i:American Constitution Party)",
+                "American Constitution Party",
+            ),
+            (r"(?i:Center Party)", "Center Party"),
+            (r"(?i:Unity Party)", "Unity Party"),
+            (r"(?i:Forward Party)", "Forward Party"),
+            (r"(?i:Approval Voting Party)", "Approval Voting Party"),
+        ]
+        .into_iter()
+        .map(|t| (Regex::new(t.0).unwrap(), t.1))
+        .collect()
+    });
+
+    for (matcher, name) in matchers {
+        if matcher.is_match(input) {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::util::extensions::*;
+
+    #[test]
+    fn extract_name() {
+        let tests: Vec<(&'static str, Option<&'static str>)> = vec![
+            ("Party", None),
+            ("Democrat", None),
+            ("Democratic", None),
+            ("Republican", None),
+            ("Libertarian", None),
+            ("American", None),
+            ("Constitution", None),
+            ("Center", None),
+            ("Unity", None),
+            ("Forward", None),
+            ("Approval", None),
+            ("Voting", None),
+            ("Affiliation", None),
+            // ----
+            ("unaffiliated", Some("Unaffiliated")),
+            ("no party affiliation", Some("Unaffiliated")),
+            ("democratic party", Some("Democratic Party")),
+            ("republican party", Some("Republican Party")),
+            ("libertarian party", Some("Libertarian Party")),
+            (
+                "american constitution party",
+                Some("American Constitution Party"),
+            ),
+            ("center party", Some("Center Party")),
+            ("unity party", Some("Unity Party")),
+            ("forward party", Some("Forward Party")),
+            ("approval voting party", Some("Approval Voting Party")),
+        ];
+
+        for (input, expected) in tests {
+            assert_eq!(
+                extract_party_name(input).as_str(),
+                expected,
+                "\n\n  Test Case: '{input}'\n"
+            );
+        }
+    }
+}

--- a/scrapers/src/generators/mod.rs
+++ b/scrapers/src/generators/mod.rs
@@ -1,9 +1,11 @@
 mod election;
 mod office;
+mod party;
 mod race;
 
 pub use election::*;
 pub use office::*;
+pub use party::*;
 pub use race::*;
 
 #[inline]

--- a/scrapers/src/generators/party.rs
+++ b/scrapers/src/generators/party.rs
@@ -1,0 +1,29 @@
+use slugify::slugify;
+
+pub struct PartySlugGenerator<'a> {
+    pub name: &'a str,
+}
+
+impl<'a> PartySlugGenerator<'a> {
+    pub fn new(name: &'a str) -> Self {
+        PartySlugGenerator { name }
+    }
+
+    pub fn generate(&self) -> String {
+        slugify!(self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn party_slug() {
+        let tests: Vec<(&'static str, &'static str)> = vec![("Bestest Party", "bestest-party")];
+
+        for (input, expected) in tests {
+            assert_eq!(PartySlugGenerator::new(input).generate(), expected);
+        }
+    }
+}


### PR DESCRIPTION
Adds Colorado Secretary of State General Election party data.

You can test this locally by running the following commands:

```bash
$ cd scrapers/
$ cargo run --bin co_sos_general_candidates
```

The `party` data will be inserted into the database associated with the `DATABASE_URL` environment variable in your `.env` file.