### PR TITLE
Add focused election REST resources

### DIFF
--- a/db/migrations/20260728180000_AddBdryVotingDistrictsSpatialExpressionIndex.down.sql
+++ b/db/migrations/20260728180000_AddBdryVotingDistrictsSpatialExpressionIndex.down.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS p6t_state_mn.bdry_votingdistricts_set_srid_geom_idx;

--- a/db/migrations/20260728180000_AddBdryVotingDistrictsSpatialExpressionIndex.up.sql
+++ b/db/migrations/20260728180000_AddBdryVotingDistrictsSpatialExpressionIndex.up.sql
@@ -1,0 +1,5 @@
+-- no-transaction
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS bdry_votingdistricts_set_srid_geom_idx
+ON p6t_state_mn.bdry_votingdistricts
+USING GIST (ST_SetSRID(geom, 26915));

--- a/db/migrations/20260728180001_AddSchoolDistrictBoundariesSpatialExpressionIndex.down.sql
+++ b/db/migrations/20260728180001_AddSchoolDistrictBoundariesSpatialExpressionIndex.down.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS p6t_state_mn.school_district_boundaries_set_srid_geom_idx;

--- a/db/migrations/20260728180001_AddSchoolDistrictBoundariesSpatialExpressionIndex.up.sql
+++ b/db/migrations/20260728180001_AddSchoolDistrictBoundariesSpatialExpressionIndex.up.sql
@@ -1,0 +1,5 @@
+-- no-transaction
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS school_district_boundaries_set_srid_geom_idx
+ON p6t_state_mn.school_district_boundaries
+USING GIST (ST_SetSRID(geom, 26915));

--- a/db/migrations/20260728180002_AddIsd2180SpatialExpressionIndex.down.sql
+++ b/db/migrations/20260728180002_AddIsd2180SpatialExpressionIndex.down.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS p6t_state_mn.isd2180_set_srid_geom_idx;

--- a/db/migrations/20260728180002_AddIsd2180SpatialExpressionIndex.up.sql
+++ b/db/migrations/20260728180002_AddIsd2180SpatialExpressionIndex.up.sql
@@ -1,0 +1,5 @@
+-- no-transaction
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS isd2180_set_srid_geom_idx
+ON p6t_state_mn.isd2180
+USING GIST (ST_SetSRID(geom, 26915));

--- a/db/migrations/20260728180003_AddIsd2853SpatialExpressionIndex.down.sql
+++ b/db/migrations/20260728180003_AddIsd2853SpatialExpressionIndex.down.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS p6t_state_mn.isd2853_set_srid_geom_idx;

--- a/db/migrations/20260728180003_AddIsd2853SpatialExpressionIndex.up.sql
+++ b/db/migrations/20260728180003_AddIsd2853SpatialExpressionIndex.up.sql
@@ -1,0 +1,5 @@
+-- no-transaction
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS isd2853_set_srid_geom_idx
+ON p6t_state_mn.isd2853
+USING GIST (ST_SetSRID(geom, 26915));

--- a/db/migrations/20260728180004_AddTxVtdsSpatialExpressionIndex.down.sql
+++ b/db/migrations/20260728180004_AddTxVtdsSpatialExpressionIndex.down.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS p6t_state_tx.tx_vtds_2026_set_srid_geom_idx;

--- a/db/migrations/20260728180004_AddTxVtdsSpatialExpressionIndex.up.sql
+++ b/db/migrations/20260728180004_AddTxVtdsSpatialExpressionIndex.up.sql
@@ -1,0 +1,5 @@
+-- no-transaction
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS tx_vtds_2026_set_srid_geom_idx
+ON p6t_state_tx.tx_vtds_2026
+USING GIST (ST_SetSRID(geom, 3081));

--- a/db/migrations/20260728180005_AddTxCongressionalSpatialExpressionIndex.down.sql
+++ b/db/migrations/20260728180005_AddTxCongressionalSpatialExpressionIndex.down.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS p6t_state_tx.tx_congressional_planc2333_set_srid_geom_idx;

--- a/db/migrations/20260728180005_AddTxCongressionalSpatialExpressionIndex.up.sql
+++ b/db/migrations/20260728180005_AddTxCongressionalSpatialExpressionIndex.up.sql
@@ -1,0 +1,5 @@
+-- no-transaction
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS tx_congressional_planc2333_set_srid_geom_idx
+ON p6t_state_tx.tx_congressional_planc2333
+USING GIST (ST_SetSRID(geom, 3081));

--- a/db/migrations/20260728180006_AddBallotMeasureElectionIdIndex.down.sql
+++ b/db/migrations/20260728180006_AddBallotMeasureElectionIdIndex.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_ballot_measure_election_id;

--- a/db/migrations/20260728180006_AddBallotMeasureElectionIdIndex.up.sql
+++ b/db/migrations/20260728180006_AddBallotMeasureElectionIdIndex.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_ballot_measure_election_id
+ON ballot_measure (election_id);

--- a/db/scripts/bootstrap_local_gis.sql
+++ b/db/scripts/bootstrap_local_gis.sql
@@ -27,6 +27,10 @@ CREATE INDEX IF NOT EXISTS tx_vtds_2026_geom_idx
     ON p6t_state_tx.tx_vtds_2026
     USING gist (geom);
 
+CREATE INDEX IF NOT EXISTS tx_vtds_2026_set_srid_geom_idx
+    ON p6t_state_tx.tx_vtds_2026
+    USING gist (ST_SetSRID(geom, 3081));
+
 CREATE TABLE IF NOT EXISTS p6t_state_tx.tx_congressional_planc2333 (
     gid BIGSERIAL PRIMARY KEY,
     cong_dist TEXT,
@@ -36,5 +40,9 @@ CREATE TABLE IF NOT EXISTS p6t_state_tx.tx_congressional_planc2333 (
 CREATE INDEX IF NOT EXISTS tx_congressional_planc2333_geom_idx
     ON p6t_state_tx.tx_congressional_planc2333
     USING gist (geom);
+
+CREATE INDEX IF NOT EXISTS tx_congressional_planc2333_set_srid_geom_idx
+    ON p6t_state_tx.tx_congressional_planc2333
+    USING gist (ST_SetSRID(geom, 3081));
 
 \ir create_mn_candidate_filings_local_2025.sql

--- a/docs/rest/openapi.yaml
+++ b/docs/rest/openapi.yaml
@@ -1,16 +1,235 @@
 openapi: 3.1.0
 info:
-  title: Populist Ballot by Address API
-  version: 1.0.0
+  title: Populist Election Data API
+  version: 1.1.0
   description: |
-    Resolves Populist election data for a US address. Results are informational
-    and are not an official sample ballot, voter-registration check,
-    polling-place lookup, or statement of voter eligibility.
+    Resource-oriented access to Populist elections, races, candidates, reported
+    results, and ballot measures. The ballot-by-address operation remains
+    available for address-specific election coverage. Results are informational
+    and are not an official result certification, sample ballot,
+    voter-registration check, polling-place lookup, or statement of voter
+    eligibility.
 servers:
   - url: /
     description: Relative to the environment base URL supplied during onboarding
 security: []
 paths:
+  /api/v1/elections:
+    get:
+      operationId: listElections
+      summary: List elections
+      description: |
+        Discovers elections in deterministic election-date and ID order.
+        Collection filters are optional and combine with AND semantics.
+      parameters:
+        - $ref: "#/components/parameters/State"
+        - $ref: "#/components/parameters/Year"
+        - $ref: "#/components/parameters/Query"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Paginated elections
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+            Cache-Control:
+              $ref: "#/components/headers/ElectionCache"
+            X-Content-Type-Options:
+              $ref: "#/components/headers/NoSniff"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ElectionCollection"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/elections/{electionId}:
+    get:
+      operationId: getElection
+      summary: Get an election
+      description: Returns election metadata for a stable election UUID.
+      parameters:
+        - $ref: "#/components/parameters/ElectionId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Election found
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+            Cache-Control:
+              $ref: "#/components/headers/ElectionCache"
+            X-Content-Type-Options:
+              $ref: "#/components/headers/NoSniff"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ElectionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/elections/{electionId}/races:
+    get:
+      operationId: listElectionRaces
+      summary: List races in an election
+      description: |
+        Returns compact race directory entries with office, party, reporting
+        summary, and update time. An existing election with no matching races
+        returns an empty collection.
+      parameters:
+        - $ref: "#/components/parameters/ElectionId"
+        - $ref: "#/components/parameters/RaceType"
+        - $ref: "#/components/parameters/PoliticalScope"
+        - $ref: "#/components/parameters/ElectionScopeFilter"
+        - $ref: "#/components/parameters/DistrictTypeFilter"
+        - $ref: "#/components/parameters/State"
+        - $ref: "#/components/parameters/Query"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Paginated election races
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+            Cache-Control:
+              $ref: "#/components/headers/ElectionDataCache"
+            X-Content-Type-Options:
+              $ref: "#/components/headers/NoSniff"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RaceCollection"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/elections/{electionId}/races/{raceId}:
+    get:
+      operationId: getElectionRace
+      summary: Get a race in an election
+      description: |
+        Returns the complete public race resource. A race UUID that does not
+        belong to the election in the path returns 404.
+      parameters:
+        - $ref: "#/components/parameters/ElectionId"
+        - $ref: "#/components/parameters/RaceId"
+        - $ref: "#/components/parameters/EndorserId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Race found in the election
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+            Cache-Control:
+              $ref: "#/components/headers/ElectionDataCache"
+            X-Content-Type-Options:
+              $ref: "#/components/headers/NoSniff"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RaceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/elections/{electionId}/results:
+    get:
+      operationId: listElectionResults
+      summary: List lightweight election results
+      description: |
+        Returns a paginated election-night feed optimized for repeated polling.
+        Each item identifies the race and office and includes candidates, vote
+        totals, winners, precinct reporting, and its last update time. Null vote
+        or reporting values mean data has not been reported; they do not mean
+        zero.
+      parameters:
+        - $ref: "#/components/parameters/ElectionId"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Paginated lightweight results
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+            Cache-Control:
+              $ref: "#/components/headers/ResultsCache"
+            X-Content-Type-Options:
+              $ref: "#/components/headers/NoSniff"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ElectionResultCollection"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/elections/{electionId}/ballot-measures:
+    get:
+      operationId: listElectionBallotMeasures
+      summary: List ballot measures in an election
+      description: |
+        Returns paginated ballot-measure reporting resources for an election.
+        This election-wide collection is not filtered to a voting address.
+      parameters:
+        - $ref: "#/components/parameters/ElectionId"
+        - $ref: "#/components/parameters/ElectionScopeFilter"
+        - $ref: "#/components/parameters/State"
+        - $ref: "#/components/parameters/BallotMeasureStatus"
+        - $ref: "#/components/parameters/County"
+        - $ref: "#/components/parameters/Municipality"
+        - $ref: "#/components/parameters/SchoolDistrict"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Paginated election ballot measures
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+            Cache-Control:
+              $ref: "#/components/headers/ElectionDataCache"
+            X-Content-Type-Options:
+              $ref: "#/components/headers/NoSniff"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BallotMeasureCollection"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/elections/{electionId}/ballot:
     post:
       operationId: getBallotByAddress
@@ -95,6 +314,127 @@ paths:
           $ref: "#/components/responses/RequestTimeout"
 components:
   parameters:
+    ElectionId:
+      name: electionId
+      in: path
+      required: true
+      description: Stable election UUID.
+      schema:
+        type: string
+        format: uuid
+    RaceId:
+      name: raceId
+      in: path
+      required: true
+      description: Stable race UUID. It must belong to the election in the path.
+      schema:
+        type: string
+        format: uuid
+    Limit:
+      name: limit
+      in: query
+      required: false
+      description: Maximum number of resources to return.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 25
+    Offset:
+      name: offset
+      in: query
+      required: false
+      description: Number of resources to skip in the deterministic ordering.
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    State:
+      name: state
+      in: query
+      required: false
+      description: Two-letter US state or territory code.
+      schema:
+        $ref: "#/components/schemas/StateCode"
+    Year:
+      name: year
+      in: query
+      required: false
+      description: Four-digit election year.
+      schema:
+        type: integer
+        minimum: 1788
+        maximum: 9999
+    Query:
+      name: query
+      in: query
+      required: false
+      description: Case-insensitive text search.
+      schema:
+        type: string
+    RaceType:
+      name: raceType
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: [primary, general]
+    PoliticalScope:
+      name: politicalScope
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: [local, state, federal]
+    ElectionScopeFilter:
+      name: electionScope
+      in: query
+      required: false
+      schema:
+        $ref: "#/components/schemas/ElectionScope"
+    DistrictTypeFilter:
+      name: districtType
+      in: query
+      required: false
+      schema:
+        $ref: "#/components/schemas/DistrictType"
+    BallotMeasureStatus:
+      name: status
+      in: query
+      required: false
+      schema:
+        $ref: "#/components/schemas/BallotMeasureStatus"
+    County:
+      name: county
+      in: query
+      required: false
+      description: Exact county name, compared case-insensitively.
+      schema:
+        type: string
+    Municipality:
+      name: municipality
+      in: query
+      required: false
+      description: Exact municipality name, compared case-insensitively.
+      schema:
+        type: string
+    SchoolDistrict:
+      name: schoolDistrict
+      in: query
+      required: false
+      description: Exact school-district identifier, compared case-insensitively.
+      schema:
+        type: string
+    EndorserId:
+      name: endorserId
+      in: query
+      required: false
+      description: |
+        Organization UUID used to filter the full race detail's candidate array
+        to candidates endorsed by that organization. Results remain unfiltered.
+      schema:
+        type: string
+        format: uuid
     RequestId:
       name: X-Request-Id
       in: header
@@ -115,6 +455,27 @@ components:
       schema:
         type: string
         const: no-store
+    ElectionCache:
+      description: |
+        Election discovery metadata can be cached for five minutes and served
+        stale while it is asynchronously revalidated.
+      schema:
+        type: string
+        const: public, max-age=300, stale-while-revalidate=900
+    ElectionDataCache:
+      description: |
+        Race and ballot-measure resources can be cached for one minute and
+        served stale while they are asynchronously revalidated.
+      schema:
+        type: string
+        const: public, max-age=60, stale-while-revalidate=300
+    ResultsCache:
+      description: |
+        Results can be cached for five seconds and served briefly stale while
+        they are asynchronously revalidated.
+      schema:
+        type: string
+        const: public, max-age=5, stale-while-revalidate=25
     NoSniff:
       description: Disables MIME-type sniffing.
       schema:
@@ -149,7 +510,7 @@ components:
                 detail: The JSON request body is invalid.
                 instance: /api/v1/elections/not-a-uuid/ballot
     NotFound:
-      description: Election does not exist
+      description: Requested election or race does not exist in this resource path
       headers:
         X-Request-Id:
           $ref: "#/components/headers/RequestId"
@@ -339,6 +700,84 @@ components:
         - WV
         - WI
         - WY
+    PaginationMeta:
+      type: object
+      additionalProperties: false
+      required: [count, total, limit, offset]
+      properties:
+        count:
+          type: integer
+          minimum: 0
+          description: Number of resources in this response.
+        total:
+          type: integer
+          minimum: 0
+          description: Total resources matching the filters.
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+        offset:
+          type: integer
+          minimum: 0
+    ElectionCollection:
+      type: object
+      additionalProperties: false
+      required: [data, meta]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ElectionMetadata"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+    ElectionResponse:
+      type: object
+      additionalProperties: false
+      required: [data]
+      properties:
+        data:
+          $ref: "#/components/schemas/ElectionMetadata"
+    RaceCollection:
+      type: object
+      additionalProperties: false
+      required: [data, meta]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/RaceSummary"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+    RaceResponse:
+      type: object
+      additionalProperties: false
+      required: [data]
+      properties:
+        data:
+          $ref: "#/components/schemas/RaceDetail"
+    ElectionResultCollection:
+      type: object
+      additionalProperties: false
+      required: [data, meta]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ElectionResult"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+    BallotMeasureCollection:
+      type: object
+      additionalProperties: false
+      required: [data, meta]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/BallotMeasureReporting"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
     BallotRequest:
       type: object
       additionalProperties: false
@@ -463,6 +902,202 @@ components:
         electionDate:
           type: string
           format: date
+    ElectionMetadata:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - title
+        - description
+        - state
+        - municipality
+        - electionDate
+      properties:
+        id:
+          type: string
+          format: uuid
+        slug:
+          type: string
+        title:
+          type: string
+        description:
+          type: [string, "null"]
+        state:
+          oneOf:
+            - $ref: "#/components/schemas/StateCode"
+            - type: "null"
+        municipality:
+          type: [string, "null"]
+        electionDate:
+          type: string
+          format: date
+    RaceSummary:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - title
+        - electionId
+        - raceType
+        - voteType
+        - state
+        - isSpecialElection
+        - numElect
+        - office
+        - party
+        - results
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        slug:
+          type: string
+        title:
+          type: string
+        electionId:
+          type: string
+          format: uuid
+        raceType:
+          type: string
+          enum: [primary, general]
+        voteType:
+          type: string
+          enum: [plurality, rankedchoice]
+        state:
+          oneOf:
+            - $ref: "#/components/schemas/StateCode"
+            - type: "null"
+        isSpecialElection:
+          type: boolean
+        numElect:
+          type: [integer, "null"]
+          format: int32
+        office:
+          $ref: "#/components/schemas/OfficeSummary"
+        party:
+          oneOf:
+            - $ref: "#/components/schemas/PartySummary"
+            - type: "null"
+        results:
+          $ref: "#/components/schemas/ResultSummary"
+        updatedAt:
+          type: string
+          format: date-time
+    OfficeSummary:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - subtitle
+        - state
+        - county
+        - municipality
+        - district
+        - seat
+        - electionScope
+        - districtType
+        - politicalScope
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        subtitle:
+          type: [string, "null"]
+        state:
+          oneOf:
+            - $ref: "#/components/schemas/StateCode"
+            - type: "null"
+        county:
+          type: [string, "null"]
+        municipality:
+          type: [string, "null"]
+        district:
+          type: [string, "null"]
+        seat:
+          type: [string, "null"]
+        electionScope:
+          $ref: "#/components/schemas/ElectionScope"
+        districtType:
+          oneOf:
+            - $ref: "#/components/schemas/DistrictType"
+            - type: "null"
+        politicalScope:
+          type: string
+          enum: [local, state, federal]
+    PartySummary:
+      type: object
+      additionalProperties: false
+      required: [id, slug, name, fecCode]
+      properties:
+        id:
+          type: string
+          format: uuid
+        slug:
+          type: string
+        name:
+          type: string
+        fecCode:
+          type: [string, "null"]
+    ResultSummary:
+      type: object
+      additionalProperties: false
+      required:
+        - totalVotes
+        - numPrecinctsReporting
+        - totalPrecincts
+        - precinctReportingPercentage
+        - winners
+      properties:
+        totalVotes:
+          type: [integer, "null"]
+          format: int32
+        numPrecinctsReporting:
+          type: [integer, "null"]
+          format: int32
+        totalPrecincts:
+          type: [integer, "null"]
+          format: int32
+        precinctReportingPercentage:
+          type: [number, "null"]
+          format: double
+        winners:
+          type: array
+          items:
+            $ref: "#/components/schemas/IdReference"
+    RaceDetail:
+      description: |
+        The full Race shape with additional reporting-source and link fields.
+        These fields are present on race detail and omitted from ballot races.
+      allOf:
+        - $ref: "#/components/schemas/Race"
+        - type: object
+          required:
+            - description
+            - ballotpediaLink
+            - earlyVotingBeginsDate
+            - officialWebsite
+            - updatedAt
+          properties:
+            description:
+              type: [string, "null"]
+            ballotpediaLink:
+              type: [string, "null"]
+              format: uri
+            earlyVotingBeginsDate:
+              type: [string, "null"]
+              format: date
+            officialWebsite:
+              type: [string, "null"]
+              format: uri
+            updatedAt:
+              type: string
+              format: date-time
     Race:
       type: object
       additionalProperties: false
@@ -535,6 +1170,20 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/RelatedEmbed"
+        description:
+          type: [string, "null"]
+        ballotpediaLink:
+          type: [string, "null"]
+          format: uri
+        earlyVotingBeginsDate:
+          type: [string, "null"]
+          format: date
+        officialWebsite:
+          type: [string, "null"]
+          format: uri
+        updatedAt:
+          type: string
+          format: date-time
     Office:
       type: object
       additionalProperties: false
@@ -712,6 +1361,82 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/IdReference"
+    ElectionResult:
+      type: object
+      additionalProperties: false
+      required:
+        - raceId
+        - slug
+        - title
+        - office
+        - candidates
+        - totalVotes
+        - numPrecinctsReporting
+        - totalPrecincts
+        - precinctReportingPercentage
+        - winners
+        - updatedAt
+      properties:
+        raceId:
+          type: string
+          format: uuid
+        slug:
+          type: string
+        title:
+          type: string
+        office:
+          $ref: "#/components/schemas/OfficeSummary"
+        candidates:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResultCandidate"
+        totalVotes:
+          type: [integer, "null"]
+          format: int32
+        numPrecinctsReporting:
+          type: [integer, "null"]
+          format: int32
+        totalPrecincts:
+          type: [integer, "null"]
+          format: int32
+        precinctReportingPercentage:
+          type: [number, "null"]
+          format: double
+        winners:
+          type: array
+          items:
+            $ref: "#/components/schemas/IdReference"
+        updatedAt:
+          type: string
+          format: date-time
+    ResultCandidate:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - fullName
+        - party
+        - votes
+        - votePercentage
+      properties:
+        id:
+          type: string
+          format: uuid
+        slug:
+          type: string
+        fullName:
+          type: string
+        party:
+          oneOf:
+            - $ref: "#/components/schemas/PartySummary"
+            - type: "null"
+        votes:
+          type: [integer, "null"]
+          format: int32
+        votePercentage:
+          type: [number, "null"]
+          format: double
     CandidateVotes:
       type: object
       additionalProperties: false
@@ -817,6 +1542,98 @@ components:
           oneOf:
             - $ref: "#/components/schemas/ElectionScope"
             - type: "null"
+    BallotMeasureReporting:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - electionId
+        - title
+        - status
+        - state
+        - county
+        - municipality
+        - schoolDistrict
+        - ballotMeasureCode
+        - measureType
+        - definitions
+        - description
+        - officialSummary
+        - populistSummary
+        - fullTextUrl
+        - yesVotes
+        - noVotes
+        - numPrecinctsReporting
+        - totalPrecincts
+        - electionScope
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        slug:
+          type: string
+        electionId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        status:
+          $ref: "#/components/schemas/BallotMeasureStatus"
+        state:
+          $ref: "#/components/schemas/StateCode"
+        county:
+          type: [string, "null"]
+        municipality:
+          type: [string, "null"]
+        schoolDistrict:
+          type: [string, "null"]
+        ballotMeasureCode:
+          type: string
+        measureType:
+          type: [string, "null"]
+        definitions:
+          type: [string, "null"]
+        description:
+          type: [string, "null"]
+        officialSummary:
+          type: [string, "null"]
+        populistSummary:
+          type: [string, "null"]
+        fullTextUrl:
+          type: [string, "null"]
+          format: uri
+        yesVotes:
+          type: [integer, "null"]
+          format: int32
+        noVotes:
+          type: [integer, "null"]
+          format: int32
+        numPrecinctsReporting:
+          type: [integer, "null"]
+          format: int32
+        totalPrecincts:
+          type: [integer, "null"]
+          format: int32
+        electionScope:
+          oneOf:
+            - $ref: "#/components/schemas/ElectionScope"
+            - type: "null"
+        updatedAt:
+          type: string
+          format: date-time
+    BallotMeasureStatus:
+      type: string
+      enum:
+        - introduced
+        - in_consideration
+        - proposed
+        - gathering_signatures
+        - on_the_ballot
+        - became_law
+        - failed
+        - unknown
     Problem:
       type: object
       additionalProperties: false

--- a/graphql/src/types/election.rs
+++ b/graphql/src/types/election.rs
@@ -16,7 +16,7 @@ use db::{
         ballot_measure::BallotMeasure,
         enums::{BallotMeasureStatus, RaceType, State, VoteType},
     },
-    Address, AddressInput, Election, ElectionScope, Race,
+    Address, AddressExtendedMN, AddressExtendedTX, AddressInput, Election, ElectionScope, Race,
 };
 use futures::FutureExt;
 use geocodio::GeocodioProxy;
@@ -48,6 +48,18 @@ pub struct ElectionRaceFilter {
 pub struct ProcessedAddress {
     pub id: Uuid,
     pub created: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct BallotAddressContext {
+    congressional_district: Option<String>,
+    state_senate_district: Option<String>,
+    state_house_district: Option<String>,
+    state: State,
+    county: Option<String>,
+    city: String,
+    extended_mn: Option<AddressExtendedMN>,
+    extended_tx: Option<AddressExtendedTX>,
 }
 
 pub async fn process_address_with_geocodio(
@@ -229,7 +241,14 @@ pub async fn get_races_by_address_id(
     election_id: &Uuid,
     address_id: &Uuid,
 ) -> Result<Vec<Race>, Error> {
-    // 1. Fetch base address info
+    let address_context = resolve_ballot_address_context(db_pool, address_id).await?;
+    get_races_by_address_context(db_pool, election_id, &address_context).await
+}
+
+pub async fn resolve_ballot_address_context(
+    db_pool: &sqlx::PgPool,
+    address_id: &Uuid,
+) -> Result<BallotAddressContext, Error> {
     let user_address_data = sqlx::query!(
         r#"
         SELECT
@@ -237,7 +256,6 @@ pub async fn get_races_by_address_id(
             a.state_senate_district,
             a.state_house_district,
             a.state AS "state:State",
-            a.postal_code,
             a.county,
             a.city
         FROM address AS a
@@ -248,13 +266,12 @@ pub async fn get_races_by_address_id(
     .fetch_one(db_pool)
     .await?;
 
-    // 2. Fetch extended state info if applicable
-    let extended_address_mn = if user_address_data.state == State::MN {
+    let extended_mn = if user_address_data.state == State::MN {
         Address::extended_mn_by_address_id(db_pool, address_id).await?
     } else {
         None
     };
-    let extended_address_tx = if user_address_data.state == State::TX {
+    let extended_tx = if user_address_data.state == State::TX {
         let result = Address::extended_tx_by_address_id(db_pool, address_id).await?;
         if result.is_none() {
             tracing::warn!(
@@ -268,7 +285,23 @@ pub async fn get_races_by_address_id(
         None
     };
 
-    // 3. Normalize extended / fallback fields
+    Ok(BallotAddressContext {
+        congressional_district: user_address_data.congressional_district,
+        state_senate_district: user_address_data.state_senate_district,
+        state_house_district: user_address_data.state_house_district,
+        state: user_address_data.state,
+        county: user_address_data.county,
+        city: user_address_data.city,
+        extended_mn,
+        extended_tx,
+    })
+}
+
+pub async fn get_races_by_address_context(
+    db_pool: &sqlx::PgPool,
+    election_id: &Uuid,
+    address_context: &BallotAddressContext,
+) -> Result<Vec<Race>, Error> {
     // For MN, use helper methods on AddressExtendedMN
     let (
         county_commissioner_district,
@@ -280,8 +313,8 @@ pub async fn get_races_by_address_id(
         school_subdistrict,
         ward,
         city,
-    ) = match &extended_address_mn {
-        Some(ext) if user_address_data.state == State::MN => (
+    ) = match &address_context.extended_mn {
+        Some(ext) if address_context.state == State::MN => (
             ext.county_commissioner_district_norm(),
             ext.judicial_district_norm(),
             ext.parsed_soil_and_water_district(),
@@ -290,7 +323,7 @@ pub async fn get_races_by_address_id(
             ext.school_district_type_norm(),
             ext.school_subdistrict_norm(),
             ext.ward_norm(),
-            ext.city_norm(&user_address_data.city),
+            ext.city_norm(&address_context.city),
         ),
         _ => (
             None,
@@ -301,7 +334,7 @@ pub async fn get_races_by_address_id(
             None,
             None,
             None,
-            user_address_data.city.clone(),
+            address_context.city.clone(),
         ),
     };
 
@@ -317,8 +350,8 @@ pub async fn get_races_by_address_id(
         tx_state_district_courts,
         tx_court_of_appeals_districts,
         tx_board_of_education_district,
-    ) = match &extended_address_tx {
-        Some(ext) if user_address_data.state == State::TX => (
+    ) = match &address_context.extended_tx {
+        Some(ext) if address_context.state == State::TX => (
             ext.precinct.clone(),
             ext.congressional_district.clone(),
             ext.state_senate_district.clone(),
@@ -333,7 +366,6 @@ pub async fn get_races_by_address_id(
         _ => (None, None, None, None, None, None, None, None, None, None),
     };
 
-    // 4. Build query
     let mut builder: QueryBuilder<Postgres> = QueryBuilder::new(
         r#"
         SELECT
@@ -369,19 +401,19 @@ pub async fn get_races_by_address_id(
     // Always include national + state scope
     builder.push(" AND (o.election_scope = 'national'");
     builder.push(" OR (o.state = ");
-    builder.push_bind(user_address_data.state);
+    builder.push_bind(address_context.state);
     builder.push(" AND o.election_scope = 'state')");
 
     // Add Minnesota‑specific filters
-    if user_address_data.state == State::MN {
+    if address_context.state == State::MN {
         apply_mn_filters(
             &mut builder,
-            user_address_data.state,
-            user_address_data.county.as_deref(),
+            address_context.state,
+            address_context.county.as_deref(),
             city.clone(),
-            user_address_data.congressional_district.clone(),
-            user_address_data.state_senate_district.clone(),
-            user_address_data.state_house_district.clone(),
+            address_context.congressional_district.clone(),
+            address_context.state_senate_district.clone(),
+            address_context.state_house_district.clone(),
             county_commissioner_district.clone(),
             judicial_district.clone(),
             school_district.clone(),
@@ -393,10 +425,10 @@ pub async fn get_races_by_address_id(
         );
     }
 
-    if user_address_data.state == State::TX {
+    if address_context.state == State::TX {
         tracing::info!(
-            state = ?user_address_data.state,
-            county = ?user_address_data.county.as_deref(),
+            state = ?address_context.state,
+            county = ?address_context.county.as_deref(),
             tx_precinct = ?tx_precinct,
             tx_congressional_district = ?tx_congressional_district,
             tx_state_senate_district = ?tx_state_senate_district,
@@ -411,8 +443,8 @@ pub async fn get_races_by_address_id(
         );
         apply_tx_filters(
             &mut builder,
-            user_address_data.state,
-            user_address_data.county.as_deref(),
+            address_context.state,
+            address_context.county.as_deref(),
             tx_precinct.clone(),
             tx_congressional_district.clone(),
             //user_address_data.congressional_district.clone(),
@@ -429,7 +461,6 @@ pub async fn get_races_by_address_id(
 
     builder.push(") ORDER BY o.priority ASC NULLS LAST, (regexp_match(o.district, '^[0-9]+'))[1]::int ASC NULLS LAST, COALESCE(o.district, '') ASC, (regexp_match(o.seat, '^[0-9]+'))[1]::int ASC NULLS LAST, COALESCE(o.seat, '') ASC, title DESC, r.id ASC");
 
-    // 5. Run query
     let query = builder.build_query_as::<Race>();
     let records = query.fetch_all(db_pool).await?;
 
@@ -441,30 +472,26 @@ pub async fn get_ballot_measures_by_address_id(
     election_id: &Uuid,
     address_id: &Uuid,
 ) -> Result<Vec<BallotMeasure>, Error> {
-    let user_address_data = sqlx::query!(
-        r#"
-        SELECT a.state AS "state:State"
-        FROM address AS a
-        WHERE a.id = $1
-        "#,
-        address_id
-    )
-    .fetch_one(db_pool)
-    .await?;
+    let address_context = resolve_ballot_address_context(db_pool, address_id).await?;
+    get_ballot_measures_by_address_context(db_pool, election_id, &address_context).await
+}
 
-    let user_address_extended_mn = if user_address_data.state == State::MN {
-        Address::extended_mn_by_address_id(db_pool, address_id).await?
-    } else {
-        None
-    };
-    let county_fips = user_address_extended_mn
+pub async fn get_ballot_measures_by_address_context(
+    db_pool: &sqlx::PgPool,
+    election_id: &Uuid,
+    address_context: &BallotAddressContext,
+) -> Result<Vec<BallotMeasure>, Error> {
+    let county_fips = address_context
+        .extended_mn
         .as_ref()
         .and_then(|address| address.county_fips.clone());
-    let municipality_fips = user_address_extended_mn
+    let municipality_fips = address_context
+        .extended_mn
         .as_ref()
         .and_then(|address| address.municipality_fips.as_deref())
         .map(|fips| fips.trim_start_matches('0').to_string());
-    let school_district = user_address_extended_mn
+    let school_district = address_context
+        .extended_mn
         .as_ref()
         .and_then(|address| address.school_district_number.as_deref())
         .map(|district| district.trim_start_matches('0').to_string());
@@ -508,7 +535,7 @@ pub async fn get_ballot_measures_by_address_id(
         ORDER BY bm.title ASC, bm.id ASC
         "#,
         election_id,
-        user_address_data.state as State,
+        address_context.state as State,
         county_fips,
         municipality_fips,
         school_district

--- a/graphql/src/types/mod.rs
+++ b/graphql/src/types/mod.rs
@@ -33,8 +33,10 @@ pub use candidate_guide::*;
 pub use committee::CommitteeResult;
 pub use conversation::ConversationResult;
 pub use election::{
-    get_ballot_measures_by_address_id, get_races_by_address_id, process_address_with_geocodio,
-    process_address_with_geocodio_status, ElectionResult, ProcessedAddress,
+    get_ballot_measures_by_address_context, get_ballot_measures_by_address_id,
+    get_races_by_address_context, get_races_by_address_id, process_address_with_geocodio,
+    process_address_with_geocodio_status, resolve_ballot_address_context, BallotAddressContext,
+    ElectionResult, ProcessedAddress,
 };
 pub use embed::*;
 pub use errors::Error;

--- a/scripts/check_ballot_rest.sh
+++ b/scripts/check_ballot_rest.sh
@@ -20,10 +20,31 @@ jq empty \
 ruby -ryaml -e '
   spec = YAML.load_file(ARGV.fetch(0))
   abort "expected OpenAPI 3.1" unless spec.fetch("openapi").start_with?("3.1.")
-  path = spec.fetch("paths").fetch("/api/v1/elections/{electionId}/ballot")
-  operation = path.fetch("post")
-  abort "missing 200 response" unless operation.fetch("responses").key?("200")
-  abort "missing ballot request schema" unless spec.fetch("components").fetch("schemas").key?("BallotRequest")
+  paths = spec.fetch("paths")
+  operations = {
+    "/api/v1/elections" => "get",
+    "/api/v1/elections/{electionId}" => "get",
+    "/api/v1/elections/{electionId}/races" => "get",
+    "/api/v1/elections/{electionId}/races/{raceId}" => "get",
+    "/api/v1/elections/{electionId}/results" => "get",
+    "/api/v1/elections/{electionId}/ballot-measures" => "get",
+    "/api/v1/elections/{electionId}/ballot" => "post",
+  }
+  operations.each do |path, method|
+    operation = paths.fetch(path).fetch(method)
+    abort "missing 200 response for #{method.upcase} #{path}" unless operation.fetch("responses").key?("200")
+  end
+  schemas = spec.fetch("components").fetch("schemas")
+  %w[
+    ElectionCollection ElectionResponse RaceCollection RaceResponse
+    ElectionResultCollection BallotMeasureCollection BallotRequest
+  ].each do |schema|
+    abort "missing #{schema} schema" unless schemas.key?(schema)
+  end
+  headers = spec.fetch("components").fetch("headers")
+  %w[ElectionCache ElectionDataCache ResultsCache NoStore].each do |header|
+    abort "missing #{header} header" unless headers.key?(header)
+  end
 ' docs/rest/openapi.yaml
 
 git diff --check

--- a/server/src/rest/ballots.rs
+++ b/server/src/rest/ballots.rs
@@ -12,15 +12,20 @@ use axum::{
 };
 use db::{
     AddressInput, BallotMeasure, DistrictType, Election, ElectionScope, Office, Party,
-    PoliticalScope, Politician, Race, State as UsState,
+    PoliticalScope, Race, State as UsState,
 };
 use graphql::types::{
-    get_ballot_measures_by_address_id, get_races_by_address_id,
-    process_address_with_geocodio_status,
+    get_ballot_measures_by_address_context, get_races_by_address_context,
+    process_address_with_geocodio_status, resolve_ballot_address_context,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::{PgPool, QueryBuilder};
-use std::{str::FromStr, sync::Arc, time::Duration};
+use sqlx::PgPool;
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 use tokio::sync::Semaphore;
 use uuid::Uuid;
 
@@ -96,51 +101,56 @@ impl DatabaseBallotLookup {
         }
     }
 
-    async fn race_resource(
+    async fn enrichment_for_races(
         &self,
-        race: Race,
-        election_date: chrono::NaiveDate,
+        races: &[Race],
         endorser_id: Option<Uuid>,
-    ) -> Result<RaceResource, sqlx::Error> {
-        let (office, party, incumbents, candidates, votes_by_candidate, related_embeds) = tokio::try_join!(
-            Office::find_by_id(&self.pool, race.office_id),
-            party_by_id(&self.pool, race.party_id),
-            incumbents_for_office(&self.pool, race.office_id),
-            candidates_for_race(&self.pool, race.id, endorser_id),
-            votes_for_race(&self.pool, race.id, race.total_votes),
-            related_embeds_for_race(&self.pool, &race),
+    ) -> Result<BallotEnrichment, sqlx::Error> {
+        if races.is_empty() {
+            return Ok(BallotEnrichment::default());
+        }
+
+        let race_ids = races.iter().map(|race| race.id).collect::<Vec<_>>();
+        let office_ids = races
+            .iter()
+            .map(|race| race.office_id)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        let (offices, incumbents, candidates, votes, related_embeds) = tokio::try_join!(
+            offices_by_ids(&self.pool, &office_ids),
+            politicians_by_office_ids(&self.pool, &office_ids),
+            politicians_by_race_ids(&self.pool, &race_ids),
+            votes_by_race_ids(&self.pool, &race_ids),
+            related_embeds_by_race_ids(&self.pool, &race_ids),
         )?;
 
-        Ok(RaceResource {
-            id: race.id.to_string(),
-            slug: race.slug,
-            title: race.title,
-            election_id: race.election_id.map(|id| id.to_string()),
-            office_id: race.office_id.to_string(),
-            race_type: race.race_type,
-            vote_type: race.vote_type,
-            state: race.state,
-            election_date,
-            is_special_election: race.is_special_election,
-            num_elect: race.num_elect,
-            party,
-            office: OfficeResource::new(office, incumbents),
-            candidates,
-            results: RaceResultsResource {
-                total_votes: race.total_votes,
-                precinct_reporting_percentage: percentage(
-                    race.num_precincts_reporting,
-                    race.total_precincts,
-                ),
-                votes_by_candidate,
-                winners: race
-                    .winner_ids
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|id| IdResource { id: id.to_string() })
-                    .collect(),
-            },
-            related_embeds,
+        let party_ids = races
+            .iter()
+            .filter_map(|race| race.party_id)
+            .chain(incumbents.iter().filter_map(|row| row.party_id))
+            .chain(candidates.iter().filter_map(|row| row.party_id))
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let candidate_ids = candidates.iter().map(|row| row.id).collect::<Vec<_>>();
+        let (parties, endorsed_candidate_ids) = tokio::try_join!(
+            parties_by_ids(&self.pool, &party_ids),
+            endorsed_candidate_ids(&self.pool, endorser_id, &candidate_ids),
+        )?;
+
+        Ok(BallotEnrichment {
+            offices: offices
+                .into_iter()
+                .map(|office| (office.id, office))
+                .collect(),
+            incumbents: politicians_by_group(incumbents),
+            candidates: politicians_by_group(candidates),
+            votes: votes_by_group(votes),
+            related_embeds: embeds_by_group(related_embeds),
+            parties: parties.into_iter().map(|party| (party.id, party)).collect(),
+            endorsed_candidate_ids,
         })
     }
 }
@@ -189,12 +199,22 @@ impl BallotLookup for DatabaseBallotLookup {
             })?;
 
         let result = async {
+            let address_context = resolve_ballot_address_context(&self.pool, &processed_address.id)
+                .await
+                .map_err(|error| {
+                    tracing::error!(
+                        error = ?error,
+                        election_id = %request.election_id,
+                        "REST ballot geography resolution failed"
+                    );
+                    BallotLookupError::Internal
+                })?;
             let (races, ballot_measures) = tokio::try_join!(
-                get_races_by_address_id(&self.pool, &request.election_id, &processed_address.id),
-                get_ballot_measures_by_address_id(
+                get_races_by_address_context(&self.pool, &request.election_id, &address_context),
+                get_ballot_measures_by_address_context(
                     &self.pool,
                     &request.election_id,
-                    &processed_address.id
+                    &address_context
                 ),
             )
             .map_err(|error| {
@@ -206,21 +226,29 @@ impl BallotLookup for DatabaseBallotLookup {
                 BallotLookupError::Internal
             })?;
 
-            let mut race_resources = Vec::with_capacity(races.len());
-            for race in races {
-                race_resources.push(
-                    self.race_resource(race, election.election_date, request.endorser_id)
-                        .await
-                        .map_err(|error| {
-                            tracing::error!(
-                                error = ?error,
-                                election_id = %request.election_id,
-                                "REST ballot response enrichment failed"
-                            );
-                            BallotLookupError::Internal
-                        })?,
-                );
-            }
+            let enrichment = self
+                .enrichment_for_races(&races, request.endorser_id)
+                .await
+                .map_err(|error| {
+                    tracing::error!(
+                        error = ?error,
+                        election_id = %request.election_id,
+                        "REST ballot response enrichment failed"
+                    );
+                    BallotLookupError::Internal
+                })?;
+            let race_resources = races
+                .into_iter()
+                .map(|race| enrichment.race_resource(race, election.election_date))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| {
+                    tracing::error!(
+                        error = ?error,
+                        election_id = %request.election_id,
+                        "REST ballot response assembly failed"
+                    );
+                    BallotLookupError::Internal
+                })?;
 
             Ok(BallotData {
                 election: ElectionResource {
@@ -281,6 +309,87 @@ pub(super) struct BallotData {
     coverage: CoverageResource,
 }
 
+#[derive(Default)]
+struct BallotEnrichment {
+    offices: HashMap<Uuid, Office>,
+    incumbents: HashMap<Uuid, Vec<BallotPoliticianRow>>,
+    candidates: HashMap<Uuid, Vec<BallotPoliticianRow>>,
+    votes: HashMap<Uuid, Vec<CandidateVotesRow>>,
+    related_embeds: HashMap<Uuid, Vec<RelatedEmbedRow>>,
+    parties: HashMap<Uuid, Party>,
+    endorsed_candidate_ids: Option<HashSet<Uuid>>,
+}
+
+impl BallotEnrichment {
+    fn race_resource(
+        &self,
+        race: Race,
+        election_date: chrono::NaiveDate,
+    ) -> Result<RaceResource, sqlx::Error> {
+        let office = self
+            .offices
+            .get(&race.office_id)
+            .ok_or(sqlx::Error::RowNotFound)?;
+        let incumbents = self
+            .incumbents
+            .get(&race.office_id)
+            .map(|rows| incumbent_resources(rows, &self.parties))
+            .unwrap_or_default();
+        let candidates = self
+            .candidates
+            .get(&race.id)
+            .map(|rows| {
+                politician_resources(rows, &self.parties, self.endorsed_candidate_ids.as_ref())
+            })
+            .unwrap_or_default();
+        let votes_by_candidate = self
+            .votes
+            .get(&race.id)
+            .map(|rows| candidate_vote_resources(rows, race.total_votes))
+            .unwrap_or_default();
+        let related_embeds = self
+            .related_embeds
+            .get(&race.id)
+            .map(|rows| related_embed_resources(rows, &race))
+            .unwrap_or_default();
+
+        Ok(RaceResource {
+            id: race.id.to_string(),
+            slug: race.slug,
+            title: race.title,
+            election_id: race.election_id.map(|id| id.to_string()),
+            office_id: race.office_id.to_string(),
+            race_type: race.race_type,
+            vote_type: race.vote_type,
+            state: race.state,
+            election_date,
+            is_special_election: race.is_special_election,
+            num_elect: race.num_elect,
+            party: race
+                .party_id
+                .and_then(|party_id| self.parties.get(&party_id))
+                .map(PartyResource::from),
+            office: OfficeResource::new(office, incumbents),
+            candidates,
+            results: RaceResultsResource {
+                total_votes: race.total_votes,
+                precinct_reporting_percentage: percentage(
+                    race.num_precincts_reporting,
+                    race.total_precincts,
+                ),
+                votes_by_candidate,
+                winners: race
+                    .winner_ids
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|id| IdResource { id: id.to_string() })
+                    .collect(),
+            },
+            related_embeds,
+        })
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CoverageResource {
@@ -328,7 +437,7 @@ struct ElectionResource {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct RaceResource {
+pub(super) struct RaceResource {
     id: String,
     slug: String,
     title: String,
@@ -345,6 +454,19 @@ struct RaceResource {
     candidates: Vec<PoliticianResource>,
     results: RaceResultsResource,
     related_embeds: Vec<EmbedResource>,
+}
+
+pub(super) async fn assemble_full_race_resource(
+    pool: &PgPool,
+    race: Race,
+    election_date: chrono::NaiveDate,
+    endorser_id: Option<Uuid>,
+) -> Result<RaceResource, sqlx::Error> {
+    let lookup = DatabaseBallotLookup::new(pool.clone());
+    let enrichment = lookup
+        .enrichment_for_races(std::slice::from_ref(&race), endorser_id)
+        .await?;
+    enrichment.race_resource(race, election_date)
 }
 
 #[derive(Debug, Serialize)]
@@ -367,7 +489,7 @@ struct OfficeResource {
 }
 
 impl OfficeResource {
-    fn new(office: Office, incumbents: Vec<IncumbentResource>) -> Self {
+    fn new(office: &Office, incumbents: Vec<IncumbentResource>) -> Self {
         let subtitle = office
             .subtitle
             .clone()
@@ -380,15 +502,15 @@ impl OfficeResource {
 
         Self {
             id: office.id.to_string(),
-            name: office.name,
-            title: office.title,
+            name: office.name.clone(),
+            title: office.title.clone(),
             subtitle,
             subtitle_short,
             state: office.state,
-            county: office.county,
-            municipality: office.municipality,
-            district: office.district,
-            seat: office.seat,
+            county: office.county.clone(),
+            municipality: office.municipality.clone(),
+            district: office.district.clone(),
+            seat: office.seat.clone(),
             election_scope: office.election_scope,
             district_type: office.district_type,
             political_scope: office.political_scope,
@@ -693,109 +815,232 @@ fn valid_postal_code(value: &str) -> bool {
             && bytes[6..10].iter().all(u8::is_ascii_digit))
 }
 
-async fn party_by_id(
-    pool: &PgPool,
-    party_id: Option<Uuid>,
-) -> Result<Option<PartyResource>, sqlx::Error> {
-    let Some(party_id) = party_id else {
-        return Ok(None);
-    };
-    sqlx::query_as::<_, Party>("SELECT * FROM party WHERE id = $1")
-        .bind(party_id)
-        .fetch_optional(pool)
-        .await
-        .map(|party| party.map(PartyResource::from))
-}
-
-impl From<Party> for PartyResource {
-    fn from(party: Party) -> Self {
+impl From<&Party> for PartyResource {
+    fn from(party: &Party) -> Self {
         Self {
-            name: party.name,
-            fec_code: party.fec_code,
+            name: party.name.clone(),
+            fec_code: party.fec_code.clone(),
         }
     }
 }
 
-async fn incumbents_for_office(
-    pool: &PgPool,
-    office_id: Uuid,
-) -> Result<Vec<IncumbentResource>, sqlx::Error> {
-    let politicians = sqlx::query_as::<_, Politician>(
-        "SELECT * FROM politician WHERE office_id = $1 ORDER BY last_name, first_name, id",
+#[derive(Clone, Debug, sqlx::FromRow)]
+struct BallotPoliticianRow {
+    group_id: Uuid,
+    id: Uuid,
+    slug: String,
+    first_name: String,
+    middle_name: Option<String>,
+    last_name: String,
+    suffix: Option<String>,
+    preferred_name: Option<String>,
+    email: Option<String>,
+    phone: Option<String>,
+    party_id: Option<Uuid>,
+    thumbnail_image_url: Option<String>,
+    assets: serde_json::Value,
+}
+
+async fn offices_by_ids(pool: &PgPool, office_ids: &[Uuid]) -> Result<Vec<Office>, sqlx::Error> {
+    sqlx::query_as::<_, Office>(
+        r#"
+        SELECT
+            id,
+            slug,
+            title,
+            subtitle,
+            subtitle_short,
+            name,
+            office_type,
+            district,
+            district_type,
+            hospital_district,
+            school_district,
+            chamber,
+            election_scope,
+            political_scope,
+            state,
+            county,
+            municipality,
+            term_length,
+            seat,
+            priority,
+            created_at,
+            updated_at
+        FROM office
+        WHERE id = ANY($1::uuid[])
+        ORDER BY id
+        "#,
     )
-    .bind(office_id)
+    .bind(office_ids)
+    .fetch_all(pool)
+    .await
+}
+
+async fn politicians_by_office_ids(
+    pool: &PgPool,
+    office_ids: &[Uuid],
+) -> Result<Vec<BallotPoliticianRow>, sqlx::Error> {
+    sqlx::query_as::<_, BallotPoliticianRow>(
+        r#"
+        SELECT
+            p.office_id AS group_id,
+            p.id,
+            p.slug,
+            p.first_name,
+            p.middle_name,
+            p.last_name,
+            p.suffix,
+            p.preferred_name,
+            p.email,
+            p.phone,
+            p.party_id,
+            p.thumbnail_image_url,
+            p.assets
+        FROM politician p
+        WHERE p.office_id = ANY($1::uuid[])
+        ORDER BY p.office_id, p.last_name, p.first_name, p.id
+        "#,
+    )
+    .bind(office_ids)
+    .fetch_all(pool)
+    .await
+}
+
+async fn politicians_by_race_ids(
+    pool: &PgPool,
+    race_ids: &[Uuid],
+) -> Result<Vec<BallotPoliticianRow>, sqlx::Error> {
+    sqlx::query_as::<_, BallotPoliticianRow>(
+        r#"
+        SELECT
+            rc.race_id AS group_id,
+            p.id,
+            p.slug,
+            p.first_name,
+            p.middle_name,
+            p.last_name,
+            p.suffix,
+            p.preferred_name,
+            p.email,
+            p.phone,
+            p.party_id,
+            p.thumbnail_image_url,
+            p.assets
+        FROM race_candidates rc
+        JOIN politician p ON p.id = rc.candidate_id
+        WHERE rc.race_id = ANY($1::uuid[])
+          AND rc.is_running = TRUE
+        ORDER BY rc.race_id, p.last_name, p.first_name, p.id
+        "#,
+    )
+    .bind(race_ids)
+    .fetch_all(pool)
+    .await
+}
+
+async fn parties_by_ids(pool: &PgPool, party_ids: &[Uuid]) -> Result<Vec<Party>, sqlx::Error> {
+    if party_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    sqlx::query_as::<_, Party>(
+        r#"
+        SELECT id, slug, name, fec_code, description, notes
+        FROM party
+        WHERE id = ANY($1::uuid[])
+        ORDER BY id
+        "#,
+    )
+    .bind(party_ids)
+    .fetch_all(pool)
+    .await
+}
+
+async fn endorsed_candidate_ids(
+    pool: &PgPool,
+    endorser_id: Option<Uuid>,
+    candidate_ids: &[Uuid],
+) -> Result<Option<HashSet<Uuid>>, sqlx::Error> {
+    let Some(endorser_id) = endorser_id else {
+        return Ok(None);
+    };
+    if candidate_ids.is_empty() {
+        return Ok(Some(HashSet::new()));
+    }
+    let ids = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        SELECT DISTINCT politician_id
+        FROM politician_organization_endorsements
+        WHERE organization_id = $1
+          AND politician_id = ANY($2::uuid[])
+        "#,
+    )
+    .bind(endorser_id)
+    .bind(candidate_ids)
     .fetch_all(pool)
     .await?;
-    let mut resources = Vec::with_capacity(politicians.len());
-    for politician in politicians {
-        let party = party_by_id(pool, politician.party_id).await?;
-        resources.push(IncumbentResource {
+    Ok(Some(ids.into_iter().collect()))
+}
+
+fn politicians_by_group(rows: Vec<BallotPoliticianRow>) -> HashMap<Uuid, Vec<BallotPoliticianRow>> {
+    let mut grouped = HashMap::new();
+    for row in rows {
+        grouped
+            .entry(row.group_id)
+            .or_insert_with(Vec::new)
+            .push(row);
+    }
+    grouped
+}
+
+fn incumbent_resources(
+    politicians: &[BallotPoliticianRow],
+    parties: &HashMap<Uuid, Party>,
+) -> Vec<IncumbentResource> {
+    politicians
+        .iter()
+        .map(|politician| IncumbentResource {
             id: politician.id.to_string(),
-            full_name: politician_full_name(&politician),
-            party,
-            thumbnail_image_url: politician.thumbnail_image_url,
-            assets: serde_json::from_value(politician.assets).unwrap_or_default(),
-        });
-    }
-    Ok(resources)
+            full_name: politician_full_name(politician),
+            party: politician
+                .party_id
+                .and_then(|party_id| parties.get(&party_id))
+                .map(PartyResource::from),
+            thumbnail_image_url: politician.thumbnail_image_url.clone(),
+            assets: serde_json::from_value(politician.assets.clone()).unwrap_or_default(),
+        })
+        .collect()
 }
 
-async fn candidates_for_race(
-    pool: &PgPool,
-    race_id: Uuid,
-    endorser_id: Option<Uuid>,
-) -> Result<Vec<PoliticianResource>, sqlx::Error> {
-    let mut builder = QueryBuilder::new(
-        "SELECT p.* FROM politician p JOIN race_candidates rc ON rc.candidate_id = p.id",
-    );
-    builder.push(" WHERE rc.race_id = ");
-    builder.push_bind(race_id);
-    builder.push(" AND rc.is_running = TRUE");
-    if let Some(endorser_id) = endorser_id {
-        builder.push(
-            " AND EXISTS (
-                SELECT 1
-                FROM politician_organization_endorsements poe
-                WHERE poe.politician_id = p.id
-                  AND poe.organization_id = ",
-        );
-        builder.push_bind(endorser_id);
-        builder.push(")");
-    }
-    builder.push(" ORDER BY p.last_name, p.first_name, p.id");
-
-    let politicians = builder
-        .build_query_as::<Politician>()
-        .fetch_all(pool)
-        .await?;
-    politician_resources(pool, politicians).await
-}
-
-async fn politician_resources(
-    pool: &PgPool,
-    politicians: Vec<Politician>,
-) -> Result<Vec<PoliticianResource>, sqlx::Error> {
-    let mut resources = Vec::with_capacity(politicians.len());
-    for politician in politicians {
-        let party = party_by_id(pool, politician.party_id).await?;
-        let full_name = politician_full_name(&politician);
-        let assets =
-            serde_json::from_value(politician.assets).unwrap_or_else(|_| Default::default());
-        resources.push(PoliticianResource {
+fn politician_resources(
+    politicians: &[BallotPoliticianRow],
+    parties: &HashMap<Uuid, Party>,
+    endorsed_candidate_ids: Option<&HashSet<Uuid>>,
+) -> Vec<PoliticianResource> {
+    politicians
+        .iter()
+        .filter(|politician| {
+            endorsed_candidate_ids
+                .map(|ids| ids.contains(&politician.id))
+                .unwrap_or(true)
+        })
+        .map(|politician| PoliticianResource {
             id: politician.id.to_string(),
-            slug: politician.slug,
-            full_name,
-            email: politician.email,
-            phone: politician.phone,
-            party,
-            thumbnail_image_url: politician.thumbnail_image_url,
-            assets,
-        });
-    }
-    Ok(resources)
+            slug: politician.slug.clone(),
+            full_name: politician_full_name(politician),
+            email: politician.email.clone(),
+            phone: politician.phone.clone(),
+            party: politician
+                .party_id
+                .and_then(|party_id| parties.get(&party_id))
+                .map(PartyResource::from),
+            thumbnail_image_url: politician.thumbnail_image_url.clone(),
+            assets: serde_json::from_value(politician.assets.clone()).unwrap_or_default(),
+        })
+        .collect()
 }
 
-fn politician_full_name(politician: &Politician) -> String {
+fn politician_full_name(politician: &BallotPoliticianRow) -> String {
     format!(
         "{} {} {}{}",
         politician
@@ -817,71 +1062,132 @@ fn politician_full_name(politician: &Politician) -> String {
 
 #[derive(sqlx::FromRow)]
 struct CandidateVotesRow {
+    race_id: Uuid,
     candidate_id: Uuid,
     votes: Option<i32>,
 }
 
-async fn votes_for_race(
+async fn votes_by_race_ids(
     pool: &PgPool,
-    race_id: Uuid,
-    total_votes: Option<i32>,
-) -> Result<Vec<CandidateVotesResource>, sqlx::Error> {
-    let rows = sqlx::query_as::<_, CandidateVotesRow>(
-        "SELECT candidate_id, votes FROM race_candidates WHERE race_id = $1 ORDER BY candidate_id",
+    race_ids: &[Uuid],
+) -> Result<Vec<CandidateVotesRow>, sqlx::Error> {
+    sqlx::query_as::<_, CandidateVotesRow>(
+        r#"
+        SELECT race_id, candidate_id, votes
+        FROM race_candidates
+        WHERE race_id = ANY($1::uuid[])
+        ORDER BY race_id, candidate_id
+        "#,
     )
-    .bind(race_id)
+    .bind(race_ids)
     .fetch_all(pool)
-    .await?;
-    Ok(rows
-        .into_iter()
+    .await
+}
+
+fn votes_by_group(rows: Vec<CandidateVotesRow>) -> HashMap<Uuid, Vec<CandidateVotesRow>> {
+    let mut grouped = HashMap::new();
+    for row in rows {
+        grouped
+            .entry(row.race_id)
+            .or_insert_with(Vec::new)
+            .push(row);
+    }
+    grouped
+}
+
+fn candidate_vote_resources(
+    rows: &[CandidateVotesRow],
+    total_votes: Option<i32>,
+) -> Vec<CandidateVotesResource> {
+    rows.iter()
         .map(|row| CandidateVotesResource {
             candidate_id: row.candidate_id.to_string(),
             votes: row.votes,
             vote_percentage: percentage(row.votes, total_votes),
         })
-        .collect())
+        .collect()
 }
 
-async fn related_embeds_for_race(
+#[derive(Clone, Debug, sqlx::FromRow)]
+struct RelatedEmbedRow {
+    race_id: Uuid,
+    id: Uuid,
+    organization_id: Uuid,
+    embed_type: db::EmbedType,
+    attributes: serde_json::Value,
+}
+
+async fn related_embeds_by_race_ids(
     pool: &PgPool,
-    race: &Race,
-) -> Result<Vec<EmbedResource>, sqlx::Error> {
-    let embeds = sqlx::query_as::<_, db::Embed>(
+    race_ids: &[Uuid],
+) -> Result<Vec<RelatedEmbedRow>, sqlx::Error> {
+    sqlx::query_as::<_, RelatedEmbedRow>(
         r#"
-        SELECT *
-        FROM embed
-        WHERE
-            attributes->>'raceId' = $1
-            OR attributes->>'politicianId' IN (
-                SELECT candidate_id::text
-                FROM race_candidates
-                WHERE race_id = $2 AND is_running = TRUE
-            )
-        ORDER BY id
+        WITH matched_embeds AS (
+            SELECT
+                requested.race_id,
+                e.id,
+                e.organization_id,
+                e.embed_type,
+                e.attributes
+            FROM unnest($1::uuid[]) AS requested(race_id)
+            JOIN embed e
+              ON e.attributes->>'raceId' = requested.race_id::text
+
+            UNION
+
+            SELECT
+                rc.race_id,
+                e.id,
+                e.organization_id,
+                e.embed_type,
+                e.attributes
+            FROM race_candidates rc
+            JOIN embed e
+              ON e.attributes->>'politicianId' = rc.candidate_id::text
+            WHERE rc.race_id = ANY($1::uuid[])
+              AND rc.is_running = TRUE
+        )
+        SELECT race_id, id, organization_id, embed_type, attributes
+        FROM matched_embeds
+        ORDER BY race_id, id
         "#,
     )
-    .bind(race.id.to_string())
-    .bind(race.id)
+    .bind(race_ids)
     .fetch_all(pool)
-    .await?;
+    .await
+}
 
-    let mut resources = Vec::with_capacity(embeds.len());
-    for embed in embeds {
-        let references_race = embed
-            .attributes
-            .get("raceId")
-            .and_then(|value| value.as_str())
-            == Some(race.id.to_string().as_str());
-        resources.push(EmbedResource {
-            id: embed.id.to_string(),
-            organization_id: embed.organization_id.to_string(),
-            embed_type: embed_type_name(embed.embed_type),
-            race: references_race.then(|| RaceReferenceResource {
-                title: race.title.clone(),
-            }),
-        });
+fn embeds_by_group(rows: Vec<RelatedEmbedRow>) -> HashMap<Uuid, Vec<RelatedEmbedRow>> {
+    let mut grouped = HashMap::new();
+    for row in rows {
+        grouped
+            .entry(row.race_id)
+            .or_insert_with(Vec::new)
+            .push(row);
     }
-    Ok(resources)
+    grouped
+}
+
+fn related_embed_resources(rows: &[RelatedEmbedRow], race: &Race) -> Vec<EmbedResource> {
+    let race_id = race.id.to_string();
+    rows.iter()
+        .map(|embed| {
+            let references_race = embed
+                .attributes
+                .get("raceId")
+                .and_then(|value| value.as_str())
+                == Some(race_id.as_str());
+            EmbedResource {
+                id: embed.id.to_string(),
+                organization_id: embed.organization_id.to_string(),
+                embed_type: embed_type_name(embed.embed_type),
+                race: references_race.then(|| RaceReferenceResource {
+                    title: race.title.clone(),
+                }),
+            }
+        })
+        .collect()
 }
 
 fn embed_type_name(embed_type: db::EmbedType) -> &'static str {
@@ -1045,9 +1351,36 @@ pub(super) fn test_ballot_data(election_id: Uuid) -> BallotData {
 }
 
 #[cfg(test)]
+pub(super) fn test_race_resource(election_id: Uuid) -> RaceResource {
+    test_ballot_data(election_id)
+        .races
+        .into_iter()
+        .next()
+        .expect("test ballot contains a race")
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn ballot_politician(group_id: Uuid, id: Uuid, first_name: &str) -> BallotPoliticianRow {
+        BallotPoliticianRow {
+            group_id,
+            id,
+            slug: first_name.to_lowercase(),
+            first_name: first_name.to_string(),
+            middle_name: None,
+            last_name: "Candidate".to_string(),
+            suffix: None,
+            preferred_name: None,
+            email: None,
+            phone: None,
+            party_id: None,
+            thumbnail_image_url: None,
+            assets: json!({}),
+        }
+    }
 
     #[test]
     fn reports_geographic_matching_coverage_by_state() {
@@ -1079,5 +1412,82 @@ mod tests {
                 ]
             })
         );
+    }
+
+    #[test]
+    fn filters_batched_candidates_by_endorser_without_changing_order() {
+        let race_id = Uuid::new_v4();
+        let first_id = Uuid::new_v4();
+        let second_id = Uuid::new_v4();
+        let politicians = vec![
+            ballot_politician(race_id, first_id, "Alice"),
+            ballot_politician(race_id, second_id, "Bob"),
+        ];
+
+        let all = politician_resources(&politicians, &HashMap::new(), None);
+        assert_eq!(
+            all.iter()
+                .map(|candidate| candidate.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![first_id.to_string(), second_id.to_string()]
+        );
+
+        let endorsed = HashSet::from([second_id]);
+        let filtered = politician_resources(&politicians, &HashMap::new(), Some(&endorsed));
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, second_id.to_string());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and reads the configured database"]
+    async fn batched_queries_decode_the_live_database_schema() {
+        dotenv::dotenv().ok();
+        let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+        let pool = PgPool::connect(&database_url)
+            .await
+            .expect("database must be reachable");
+        let race_rows = sqlx::query_as::<_, (Uuid, Uuid)>(
+            r#"
+            SELECT id, office_id
+            FROM race
+            ORDER BY updated_at DESC
+            LIMIT 20
+            "#,
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("sample races should load");
+        assert!(!race_rows.is_empty());
+
+        let expected_office_count = race_rows
+            .iter()
+            .map(|row| row.1)
+            .collect::<HashSet<_>>()
+            .len();
+        let mut races = Vec::with_capacity(race_rows.len());
+        for (race_id, _) in race_rows {
+            races.push(
+                Race::find_by_id(&pool, race_id)
+                    .await
+                    .expect("sample race should decode"),
+            );
+        }
+
+        let lookup = DatabaseBallotLookup::new(pool);
+        let enrichment = lookup
+            .enrichment_for_races(&races, None)
+            .await
+            .expect("batched enrichment queries should decode");
+        assert_eq!(enrichment.offices.len(), expected_office_count);
+
+        let resources = races
+            .into_iter()
+            .map(|race| {
+                enrichment
+                    .race_resource(race, chrono::NaiveDate::from_ymd_opt(2026, 11, 3).unwrap())
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .expect("batched resources should assemble");
+        assert!(!resources.is_empty());
     }
 }

--- a/server/src/rest/elections.rs
+++ b/server/src/rest/elections.rs
@@ -1,0 +1,1453 @@
+use async_trait::async_trait;
+use axum::{
+    extract::{rejection::QueryRejection, Path, Query, State},
+    http::{header::CACHE_CONTROL, HeaderMap, HeaderValue},
+    Json,
+};
+use db::{
+    BallotMeasure, DistrictType, Election, ElectionScope, PoliticalScope, Race, RaceType,
+    State as UsState, VoteType,
+};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, Postgres, QueryBuilder};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use super::{
+    ballots::{assemble_full_race_resource, RaceResource},
+    error::ApiError,
+    pagination::{DEFAULT_LIMIT, MAX_LIMIT},
+    RestState,
+};
+
+const ELECTIONS_ENDPOINT: &str = "/api/v1/elections";
+const CACHE_METADATA: HeaderValue =
+    HeaderValue::from_static("public, max-age=300, stale-while-revalidate=900");
+const CACHE_COLLECTION: HeaderValue =
+    HeaderValue::from_static("public, max-age=60, stale-while-revalidate=300");
+const CACHE_RESULTS: HeaderValue =
+    HeaderValue::from_static("public, max-age=5, stale-while-revalidate=25");
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct PageRequest {
+    pub(super) limit: usize,
+    pub(super) offset: usize,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct ElectionFilters {
+    pub(super) state: Option<UsState>,
+    pub(super) year: Option<i32>,
+    pub(super) query: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct RaceFilters {
+    pub(super) state: Option<UsState>,
+    pub(super) race_type: Option<RaceType>,
+    pub(super) political_scope: Option<PoliticalScope>,
+    pub(super) election_scope: Option<ElectionScope>,
+    pub(super) district_type: Option<DistrictType>,
+    pub(super) query: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct BallotMeasureFilters {
+    pub(super) state: Option<UsState>,
+    pub(super) status: Option<&'static str>,
+    pub(super) election_scope: Option<ElectionScope>,
+    pub(super) county: Option<String>,
+    pub(super) municipality: Option<String>,
+    pub(super) school_district: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, thiserror::Error)]
+pub(super) enum ElectionDataError {
+    #[error("election not found")]
+    ElectionNotFound,
+    #[error("race not found")]
+    RaceNotFound,
+    #[error("election data lookup failed")]
+    Internal,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ElectionResource {
+    pub(super) id: String,
+    pub(super) slug: String,
+    pub(super) title: String,
+    pub(super) description: Option<String>,
+    pub(super) state: Option<UsState>,
+    pub(super) municipality: Option<String>,
+    pub(super) election_date: chrono::NaiveDate,
+}
+
+impl From<Election> for ElectionResource {
+    fn from(election: Election) -> Self {
+        Self {
+            id: election.id.to_string(),
+            slug: election.slug,
+            title: election.title,
+            description: election.description,
+            state: election.state,
+            municipality: election.municipality,
+            election_date: election.election_date,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct OfficeSummaryResource {
+    pub(super) id: String,
+    pub(super) title: String,
+    pub(super) subtitle: Option<String>,
+    pub(super) state: Option<UsState>,
+    pub(super) county: Option<String>,
+    pub(super) municipality: Option<String>,
+    pub(super) district: Option<String>,
+    pub(super) seat: Option<String>,
+    pub(super) election_scope: ElectionScope,
+    pub(super) district_type: Option<DistrictType>,
+    pub(super) political_scope: PoliticalScope,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct PartySummaryResource {
+    pub(super) id: String,
+    pub(super) slug: String,
+    pub(super) name: String,
+    pub(super) fec_code: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ResultSummaryResource {
+    pub(super) total_votes: Option<i32>,
+    pub(super) num_precincts_reporting: Option<i32>,
+    pub(super) total_precincts: Option<i32>,
+    pub(super) precinct_reporting_percentage: Option<f64>,
+    pub(super) winners: Vec<IdResource>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct IdResource {
+    pub(super) id: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RaceSummaryResource {
+    pub(super) id: String,
+    pub(super) slug: String,
+    pub(super) title: String,
+    pub(super) election_id: String,
+    pub(super) race_type: RaceType,
+    pub(super) vote_type: VoteType,
+    pub(super) state: Option<UsState>,
+    pub(super) is_special_election: bool,
+    pub(super) num_elect: Option<i32>,
+    pub(super) office: OfficeSummaryResource,
+    pub(super) party: Option<PartySummaryResource>,
+    pub(super) results: ResultSummaryResource,
+    pub(super) updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RaceDetailResource {
+    #[serde(flatten)]
+    pub(super) race: RaceResource,
+    pub(super) description: Option<String>,
+    pub(super) ballotpedia_link: Option<String>,
+    pub(super) early_voting_begins_date: Option<chrono::NaiveDate>,
+    pub(super) official_website: Option<String>,
+    pub(super) updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct CandidateResultResource {
+    pub(super) id: String,
+    pub(super) slug: String,
+    pub(super) full_name: String,
+    pub(super) party: Option<PartySummaryResource>,
+    pub(super) votes: Option<i32>,
+    pub(super) vote_percentage: Option<f64>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RaceResultsFeedResource {
+    pub(super) race_id: String,
+    pub(super) slug: String,
+    pub(super) title: String,
+    pub(super) office: OfficeSummaryResource,
+    pub(super) total_votes: Option<i32>,
+    pub(super) num_precincts_reporting: Option<i32>,
+    pub(super) total_precincts: Option<i32>,
+    pub(super) precinct_reporting_percentage: Option<f64>,
+    pub(super) candidates: Vec<CandidateResultResource>,
+    pub(super) winners: Vec<IdResource>,
+    pub(super) updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct BallotMeasureResource {
+    pub(super) id: String,
+    pub(super) slug: String,
+    pub(super) title: String,
+    pub(super) status: &'static str,
+    pub(super) election_id: String,
+    pub(super) state: UsState,
+    pub(super) county: Option<String>,
+    pub(super) municipality: Option<String>,
+    pub(super) school_district: Option<String>,
+    pub(super) ballot_measure_code: String,
+    pub(super) measure_type: Option<String>,
+    pub(super) definitions: Option<String>,
+    pub(super) description: Option<String>,
+    pub(super) official_summary: Option<String>,
+    pub(super) populist_summary: Option<String>,
+    pub(super) full_text_url: Option<String>,
+    pub(super) yes_votes: Option<i32>,
+    pub(super) no_votes: Option<i32>,
+    pub(super) num_precincts_reporting: Option<i32>,
+    pub(super) total_precincts: Option<i32>,
+    pub(super) election_scope: Option<ElectionScope>,
+    pub(super) updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<BallotMeasure> for BallotMeasureResource {
+    fn from(measure: BallotMeasure) -> Self {
+        Self {
+            id: measure.id.to_string(),
+            slug: measure.slug,
+            title: measure.title,
+            status: ballot_measure_status_name(measure.status),
+            election_id: measure.election_id.to_string(),
+            state: measure.state,
+            county: measure.county,
+            municipality: measure.municipality,
+            school_district: measure.school_district,
+            ballot_measure_code: measure.ballot_measure_code,
+            measure_type: measure.measure_type,
+            definitions: measure.definitions,
+            description: measure.description,
+            official_summary: measure.official_summary,
+            populist_summary: measure.populist_summary,
+            full_text_url: measure.full_text_url,
+            yes_votes: measure.yes_votes,
+            no_votes: measure.no_votes,
+            num_precincts_reporting: measure.num_precincts_reporting,
+            total_precincts: measure.total_precincts,
+            election_scope: measure.election_scope,
+            updated_at: measure.updated_at,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct PaginationMeta {
+    pub(super) count: usize,
+    pub(super) total: usize,
+    pub(super) limit: usize,
+    pub(super) offset: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct Collection<T> {
+    pub(super) data: Vec<T>,
+    pub(super) meta: PaginationMeta,
+}
+
+impl<T> Collection<T> {
+    pub(super) fn new(data: Vec<T>, total: usize, page: PageRequest) -> Self {
+        Self {
+            meta: PaginationMeta {
+                count: data.len(),
+                total,
+                limit: page.limit,
+                offset: page.offset,
+            },
+            data,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct Resource<T> {
+    pub(super) data: T,
+}
+
+#[async_trait]
+pub(super) trait ElectionDataLookup: Send + Sync {
+    async fn elections(
+        &self,
+        filters: ElectionFilters,
+        page: PageRequest,
+    ) -> Result<Collection<ElectionResource>, ElectionDataError>;
+
+    async fn election(&self, election_id: Uuid) -> Result<ElectionResource, ElectionDataError>;
+
+    async fn races(
+        &self,
+        election_id: Uuid,
+        filters: RaceFilters,
+        page: PageRequest,
+    ) -> Result<Collection<RaceSummaryResource>, ElectionDataError>;
+
+    async fn race(
+        &self,
+        election_id: Uuid,
+        race_id: Uuid,
+        endorser_id: Option<Uuid>,
+    ) -> Result<RaceDetailResource, ElectionDataError>;
+
+    async fn results(
+        &self,
+        election_id: Uuid,
+        page: PageRequest,
+    ) -> Result<Collection<RaceResultsFeedResource>, ElectionDataError>;
+
+    async fn ballot_measures(
+        &self,
+        election_id: Uuid,
+        filters: BallotMeasureFilters,
+        page: PageRequest,
+    ) -> Result<Collection<BallotMeasureResource>, ElectionDataError>;
+}
+
+pub(super) struct DatabaseElectionDataLookup {
+    pool: PgPool,
+}
+
+impl DatabaseElectionDataLookup {
+    pub(super) fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    async fn require_election(&self, election_id: Uuid) -> Result<Election, ElectionDataError> {
+        Election::find_by_id(&self.pool, election_id)
+            .await
+            .map_err(map_election_error)
+    }
+}
+
+#[async_trait]
+impl ElectionDataLookup for DatabaseElectionDataLookup {
+    async fn elections(
+        &self,
+        filters: ElectionFilters,
+        page: PageRequest,
+    ) -> Result<Collection<ElectionResource>, ElectionDataError> {
+        let mut count =
+            QueryBuilder::<Postgres>::new("SELECT COUNT(*)::bigint FROM election e WHERE TRUE");
+        apply_election_filters(&mut count, &filters);
+        let total = count
+            .build_query_scalar::<i64>()
+            .fetch_one(&self.pool)
+            .await
+            .map_err(log_internal)?
+            .max(0) as usize;
+
+        let mut query = QueryBuilder::<Postgres>::new(
+            r#"
+            SELECT
+                e.id, e.slug, e.title, e.description, e.state, e.municipality,
+                e.election_date
+            FROM election e
+            WHERE TRUE
+            "#,
+        );
+        apply_election_filters(&mut query, &filters);
+        query.push(" ORDER BY e.election_date DESC, e.title ASC, e.id ASC LIMIT ");
+        query.push_bind(page.limit as i64);
+        query.push(" OFFSET ");
+        query.push_bind(page.offset as i64);
+        let data = query
+            .build_query_as::<Election>()
+            .fetch_all(&self.pool)
+            .await
+            .map_err(log_internal)?
+            .into_iter()
+            .map(ElectionResource::from)
+            .collect();
+        Ok(Collection::new(data, total, page))
+    }
+
+    async fn election(&self, election_id: Uuid) -> Result<ElectionResource, ElectionDataError> {
+        self.require_election(election_id)
+            .await
+            .map(ElectionResource::from)
+    }
+
+    async fn races(
+        &self,
+        election_id: Uuid,
+        filters: RaceFilters,
+        page: PageRequest,
+    ) -> Result<Collection<RaceSummaryResource>, ElectionDataError> {
+        self.require_election(election_id).await?;
+        let mut count = QueryBuilder::<Postgres>::new(
+            "SELECT COUNT(*)::bigint FROM race r JOIN office o ON o.id = r.office_id WHERE r.election_id = ",
+        );
+        count.push_bind(election_id);
+        apply_race_filters(&mut count, &filters);
+        let total = count
+            .build_query_scalar::<i64>()
+            .fetch_one(&self.pool)
+            .await
+            .map_err(log_internal)?
+            .max(0) as usize;
+
+        let mut query = QueryBuilder::<Postgres>::new(
+            r#"
+            SELECT
+                r.id, r.slug, r.title, r.election_id, r.race_type, r.vote_type,
+                r.state, r.is_special_election, r.num_elect, r.total_votes,
+                r.num_precincts_reporting, r.total_precincts, r.winner_ids,
+                r.updated_at,
+                o.id AS office_id, o.title AS office_title, o.subtitle AS office_subtitle,
+                o.state AS office_state, o.county AS office_county,
+                o.municipality AS office_municipality, o.district AS office_district,
+                o.seat AS office_seat, o.election_scope, o.district_type,
+                o.political_scope,
+                p.id AS party_id, p.slug AS party_slug, p.name AS party_name,
+                p.fec_code AS party_fec_code
+            FROM race r
+            JOIN office o ON o.id = r.office_id
+            LEFT JOIN party p ON p.id = r.party_id
+            WHERE r.election_id =
+            "#,
+        );
+        query.push_bind(election_id);
+        apply_race_filters(&mut query, &filters);
+        push_race_order(&mut query);
+        query.push(" LIMIT ");
+        query.push_bind(page.limit as i64);
+        query.push(" OFFSET ");
+        query.push_bind(page.offset as i64);
+        let data = query
+            .build_query_as::<RaceDirectoryRow>()
+            .fetch_all(&self.pool)
+            .await
+            .map_err(log_internal)?
+            .into_iter()
+            .map(RaceSummaryResource::from)
+            .collect();
+        Ok(Collection::new(data, total, page))
+    }
+
+    async fn race(
+        &self,
+        election_id: Uuid,
+        race_id: Uuid,
+        endorser_id: Option<Uuid>,
+    ) -> Result<RaceDetailResource, ElectionDataError> {
+        let election = self.require_election(election_id).await?;
+        let race = Race::find_by_id(&self.pool, race_id)
+            .await
+            .map_err(map_race_error)?;
+        if race.election_id != Some(election_id) {
+            return Err(ElectionDataError::RaceNotFound);
+        }
+        let description = race.description.clone();
+        let ballotpedia_link = race.ballotpedia_link.clone();
+        let early_voting_begins_date = race.early_voting_begins_date;
+        let official_website = race.official_website.clone();
+        let updated_at = race.updated_at;
+        let race =
+            assemble_full_race_resource(&self.pool, race, election.election_date, endorser_id)
+                .await
+                .map_err(log_internal)?;
+        Ok(RaceDetailResource {
+            race,
+            description,
+            ballotpedia_link,
+            early_voting_begins_date,
+            official_website,
+            updated_at,
+        })
+    }
+
+    async fn results(
+        &self,
+        election_id: Uuid,
+        page: PageRequest,
+    ) -> Result<Collection<RaceResultsFeedResource>, ElectionDataError> {
+        self.require_election(election_id).await?;
+        let total = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*)::bigint FROM race WHERE election_id = $1",
+        )
+        .bind(election_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(log_internal)?
+        .max(0) as usize;
+        let rows = sqlx::query_as::<_, ResultsRow>(
+            r#"
+            WITH selected_races AS (
+                SELECT
+                    r.id, r.slug, r.title, r.total_votes, r.num_precincts_reporting,
+                    r.total_precincts, r.winner_ids, r.updated_at,
+                    o.id AS office_id, o.title AS office_title,
+                    o.subtitle AS office_subtitle, o.state AS office_state,
+                    o.county AS office_county, o.municipality AS office_municipality,
+                    o.district AS office_district, o.seat AS office_seat,
+                    o.election_scope, o.district_type, o.political_scope,
+                    o.priority
+                FROM race r
+                JOIN office o ON o.id = r.office_id
+                WHERE r.election_id = $1
+                ORDER BY
+                    o.priority ASC NULLS LAST,
+                    (regexp_match(o.district, '^[0-9]+'))[1]::int ASC NULLS LAST,
+                    COALESCE(o.district, '') ASC,
+                    (regexp_match(o.seat, '^[0-9]+'))[1]::int ASC NULLS LAST,
+                    COALESCE(o.seat, '') ASC,
+                    r.title DESC,
+                    r.id ASC
+                LIMIT $2 OFFSET $3
+            )
+            SELECT
+                sr.id AS race_id, sr.slug AS race_slug, sr.title AS race_title,
+                sr.total_votes, sr.num_precincts_reporting, sr.total_precincts,
+                sr.winner_ids, sr.updated_at,
+                sr.office_id, sr.office_title, sr.office_subtitle, sr.office_state,
+                sr.office_county, sr.office_municipality, sr.office_district,
+                sr.office_seat, sr.election_scope, sr.district_type,
+                sr.political_scope,
+                candidate.id AS candidate_id, candidate.slug AS candidate_slug,
+                candidate.first_name, candidate.middle_name, candidate.last_name,
+                candidate.suffix, candidate.preferred_name, rc.votes,
+                party.id AS party_id, party.slug AS party_slug,
+                party.name AS party_name, party.fec_code AS party_fec_code
+            FROM selected_races sr
+            LEFT JOIN race_candidates rc
+              ON rc.race_id = sr.id AND rc.is_running = TRUE
+            LEFT JOIN politician candidate ON candidate.id = rc.candidate_id
+            LEFT JOIN party ON party.id = candidate.party_id
+            ORDER BY
+                sr.priority ASC NULLS LAST,
+                (regexp_match(sr.office_district, '^[0-9]+'))[1]::int ASC NULLS LAST,
+                COALESCE(sr.office_district, '') ASC,
+                (regexp_match(sr.office_seat, '^[0-9]+'))[1]::int ASC NULLS LAST,
+                COALESCE(sr.office_seat, '') ASC,
+                sr.title DESC,
+                sr.id ASC,
+                candidate.last_name ASC NULLS LAST,
+                candidate.first_name ASC NULLS LAST,
+                candidate.id ASC NULLS LAST
+            "#,
+        )
+        .bind(election_id)
+        .bind(page.limit as i64)
+        .bind(page.offset as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(log_internal)?;
+        Ok(Collection::new(group_results(rows), total, page))
+    }
+
+    async fn ballot_measures(
+        &self,
+        election_id: Uuid,
+        filters: BallotMeasureFilters,
+        page: PageRequest,
+    ) -> Result<Collection<BallotMeasureResource>, ElectionDataError> {
+        self.require_election(election_id).await?;
+        let mut count = QueryBuilder::<Postgres>::new(
+            "SELECT COUNT(*)::bigint FROM ballot_measure bm WHERE bm.election_id = ",
+        );
+        count.push_bind(election_id);
+        apply_ballot_measure_filters(&mut count, &filters);
+        let total = count
+            .build_query_scalar::<i64>()
+            .fetch_one(&self.pool)
+            .await
+            .map_err(log_internal)?
+            .max(0) as usize;
+
+        let mut query = QueryBuilder::<Postgres>::new(
+            "SELECT bm.* FROM ballot_measure bm WHERE bm.election_id = ",
+        );
+        query.push_bind(election_id);
+        apply_ballot_measure_filters(&mut query, &filters);
+        query.push(" ORDER BY bm.title ASC, bm.id ASC LIMIT ");
+        query.push_bind(page.limit as i64);
+        query.push(" OFFSET ");
+        query.push_bind(page.offset as i64);
+        let data = query
+            .build_query_as::<BallotMeasure>()
+            .fetch_all(&self.pool)
+            .await
+            .map_err(log_internal)?
+            .into_iter()
+            .map(BallotMeasureResource::from)
+            .collect();
+        Ok(Collection::new(data, total, page))
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct RaceDirectoryRow {
+    id: Uuid,
+    slug: String,
+    title: String,
+    election_id: Option<Uuid>,
+    race_type: RaceType,
+    vote_type: VoteType,
+    state: Option<UsState>,
+    is_special_election: bool,
+    num_elect: Option<i32>,
+    total_votes: Option<i32>,
+    num_precincts_reporting: Option<i32>,
+    total_precincts: Option<i32>,
+    winner_ids: Option<Vec<Uuid>>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    office_id: Uuid,
+    office_title: String,
+    office_subtitle: Option<String>,
+    office_state: Option<UsState>,
+    office_county: Option<String>,
+    office_municipality: Option<String>,
+    office_district: Option<String>,
+    office_seat: Option<String>,
+    election_scope: ElectionScope,
+    district_type: Option<DistrictType>,
+    political_scope: PoliticalScope,
+    party_id: Option<Uuid>,
+    party_slug: Option<String>,
+    party_name: Option<String>,
+    party_fec_code: Option<String>,
+}
+
+impl From<RaceDirectoryRow> for RaceSummaryResource {
+    fn from(row: RaceDirectoryRow) -> Self {
+        Self {
+            id: row.id.to_string(),
+            slug: row.slug,
+            title: row.title,
+            election_id: row.election_id.unwrap_or_default().to_string(),
+            race_type: row.race_type,
+            vote_type: row.vote_type,
+            state: row.state,
+            is_special_election: row.is_special_election,
+            num_elect: row.num_elect,
+            office: office_resource(
+                row.office_id,
+                row.office_title,
+                row.office_subtitle,
+                row.office_state,
+                row.office_county,
+                row.office_municipality,
+                row.office_district,
+                row.office_seat,
+                row.election_scope,
+                row.district_type,
+                row.political_scope,
+            ),
+            party: party_resource(
+                row.party_id,
+                row.party_slug,
+                row.party_name,
+                row.party_fec_code,
+            ),
+            results: ResultSummaryResource {
+                total_votes: row.total_votes,
+                num_precincts_reporting: row.num_precincts_reporting,
+                total_precincts: row.total_precincts,
+                precinct_reporting_percentage: percentage(
+                    row.num_precincts_reporting,
+                    row.total_precincts,
+                ),
+                winners: ids(row.winner_ids),
+            },
+            updated_at: row.updated_at,
+        }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct ResultsRow {
+    race_id: Uuid,
+    race_slug: String,
+    race_title: String,
+    total_votes: Option<i32>,
+    num_precincts_reporting: Option<i32>,
+    total_precincts: Option<i32>,
+    winner_ids: Option<Vec<Uuid>>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    office_id: Uuid,
+    office_title: String,
+    office_subtitle: Option<String>,
+    office_state: Option<UsState>,
+    office_county: Option<String>,
+    office_municipality: Option<String>,
+    office_district: Option<String>,
+    office_seat: Option<String>,
+    election_scope: ElectionScope,
+    district_type: Option<DistrictType>,
+    political_scope: PoliticalScope,
+    candidate_id: Option<Uuid>,
+    candidate_slug: Option<String>,
+    first_name: Option<String>,
+    middle_name: Option<String>,
+    last_name: Option<String>,
+    suffix: Option<String>,
+    preferred_name: Option<String>,
+    votes: Option<i32>,
+    party_id: Option<Uuid>,
+    party_slug: Option<String>,
+    party_name: Option<String>,
+    party_fec_code: Option<String>,
+}
+
+fn group_results(rows: Vec<ResultsRow>) -> Vec<RaceResultsFeedResource> {
+    let mut results: Vec<RaceResultsFeedResource> = Vec::new();
+    for row in rows {
+        let is_new_race = results
+            .last()
+            .map(|race| race.race_id != row.race_id.to_string())
+            .unwrap_or(true);
+        if is_new_race {
+            results.push(RaceResultsFeedResource {
+                race_id: row.race_id.to_string(),
+                slug: row.race_slug.clone(),
+                title: row.race_title.clone(),
+                office: office_resource(
+                    row.office_id,
+                    row.office_title.clone(),
+                    row.office_subtitle.clone(),
+                    row.office_state,
+                    row.office_county.clone(),
+                    row.office_municipality.clone(),
+                    row.office_district.clone(),
+                    row.office_seat.clone(),
+                    row.election_scope,
+                    row.district_type,
+                    row.political_scope,
+                ),
+                total_votes: row.total_votes,
+                num_precincts_reporting: row.num_precincts_reporting,
+                total_precincts: row.total_precincts,
+                precinct_reporting_percentage: percentage(
+                    row.num_precincts_reporting,
+                    row.total_precincts,
+                ),
+                candidates: Vec::new(),
+                winners: ids(row.winner_ids.clone()),
+                updated_at: row.updated_at,
+            });
+        }
+        if let Some(candidate_id) = row.candidate_id {
+            let full_name = full_name(
+                row.preferred_name.as_deref().or(row.first_name.as_deref()),
+                row.middle_name.as_deref(),
+                row.last_name.as_deref(),
+                row.suffix.as_deref(),
+            );
+            let total_votes = row.total_votes;
+            results
+                .last_mut()
+                .expect("a result was inserted for this row")
+                .candidates
+                .push(CandidateResultResource {
+                    id: candidate_id.to_string(),
+                    slug: row.candidate_slug.unwrap_or_default(),
+                    full_name,
+                    party: party_resource(
+                        row.party_id,
+                        row.party_slug,
+                        row.party_name,
+                        row.party_fec_code,
+                    ),
+                    votes: row.votes,
+                    vote_percentage: percentage(row.votes, total_votes),
+                });
+        }
+    }
+    results
+}
+
+fn apply_election_filters(builder: &mut QueryBuilder<Postgres>, filters: &ElectionFilters) {
+    if let Some(state) = filters.state {
+        builder.push(" AND e.state = ");
+        builder.push_bind(state);
+    }
+    if let Some(year) = filters.year {
+        builder.push(" AND EXTRACT(YEAR FROM e.election_date)::integer = ");
+        builder.push_bind(year);
+    }
+    if let Some(query) = filters.query.as_deref() {
+        builder.push(
+            " AND LOWER(e.title || ' ' || COALESCE(e.description, '') || ' ' || COALESCE(e.municipality, '')) LIKE ",
+        );
+        builder.push_bind(format!("%{}%", query.to_lowercase()));
+    }
+}
+
+fn apply_race_filters(builder: &mut QueryBuilder<Postgres>, filters: &RaceFilters) {
+    if let Some(state) = filters.state {
+        builder.push(" AND r.state = ");
+        builder.push_bind(state);
+    }
+    if let Some(race_type) = filters.race_type {
+        builder.push(" AND r.race_type = ");
+        builder.push_bind(race_type);
+    }
+    if let Some(scope) = filters.political_scope {
+        builder.push(" AND o.political_scope = ");
+        builder.push_bind(scope);
+    }
+    if let Some(scope) = filters.election_scope {
+        builder.push(" AND o.election_scope = ");
+        builder.push_bind(scope);
+    }
+    if let Some(district_type) = filters.district_type {
+        builder.push(" AND o.district_type = ");
+        builder.push_bind(district_type);
+    }
+    if let Some(query) = filters.query.as_deref() {
+        builder.push(" AND LOWER(r.title || ' ' || o.title) LIKE ");
+        builder.push_bind(format!("%{}%", query.to_lowercase()));
+    }
+}
+
+fn apply_ballot_measure_filters(
+    builder: &mut QueryBuilder<Postgres>,
+    filters: &BallotMeasureFilters,
+) {
+    if let Some(state) = filters.state {
+        builder.push(" AND bm.state = ");
+        builder.push_bind(state);
+    }
+    if let Some(status) = filters.status {
+        builder.push(" AND bm.status::text = ");
+        builder.push_bind(status);
+    }
+    if let Some(scope) = filters.election_scope {
+        builder.push(" AND bm.election_scope = ");
+        builder.push_bind(scope);
+    }
+    if let Some(county) = filters.county.as_deref() {
+        builder.push(" AND LOWER(bm.county) = ");
+        builder.push_bind(county.to_lowercase());
+    }
+    if let Some(municipality) = filters.municipality.as_deref() {
+        builder.push(" AND LOWER(bm.municipality) = ");
+        builder.push_bind(municipality.to_lowercase());
+    }
+    if let Some(school_district) = filters.school_district.as_deref() {
+        builder.push(" AND LOWER(bm.school_district) = ");
+        builder.push_bind(school_district.to_lowercase());
+    }
+}
+
+fn push_race_order(builder: &mut QueryBuilder<Postgres>) {
+    builder.push(
+        " ORDER BY o.priority ASC NULLS LAST, \
+         (regexp_match(o.district, '^[0-9]+'))[1]::int ASC NULLS LAST, \
+         COALESCE(o.district, '') ASC, \
+         (regexp_match(o.seat, '^[0-9]+'))[1]::int ASC NULLS LAST, \
+         COALESCE(o.seat, '') ASC, r.title DESC, r.id ASC",
+    );
+}
+
+fn office_resource(
+    id: Uuid,
+    title: String,
+    subtitle: Option<String>,
+    state: Option<UsState>,
+    county: Option<String>,
+    municipality: Option<String>,
+    district: Option<String>,
+    seat: Option<String>,
+    election_scope: ElectionScope,
+    district_type: Option<DistrictType>,
+    political_scope: PoliticalScope,
+) -> OfficeSummaryResource {
+    OfficeSummaryResource {
+        id: id.to_string(),
+        title,
+        subtitle,
+        state,
+        county,
+        municipality,
+        district,
+        seat,
+        election_scope,
+        district_type,
+        political_scope,
+    }
+}
+
+fn party_resource(
+    id: Option<Uuid>,
+    slug: Option<String>,
+    name: Option<String>,
+    fec_code: Option<String>,
+) -> Option<PartySummaryResource> {
+    Some(PartySummaryResource {
+        id: id?.to_string(),
+        slug: slug?,
+        name: name?,
+        fec_code,
+    })
+}
+
+fn ids(values: Option<Vec<Uuid>>) -> Vec<IdResource> {
+    values
+        .unwrap_or_default()
+        .into_iter()
+        .map(|id| IdResource { id: id.to_string() })
+        .collect()
+}
+
+fn full_name(
+    first: Option<&str>,
+    middle: Option<&str>,
+    last: Option<&str>,
+    suffix: Option<&str>,
+) -> String {
+    [first, middle, last, suffix]
+        .into_iter()
+        .flatten()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn percentage(numerator: Option<i32>, denominator: Option<i32>) -> Option<f64> {
+    match (numerator, denominator) {
+        (Some(numerator), Some(denominator)) if denominator > 0 => {
+            Some(((f64::from(numerator) / f64::from(denominator) * 100.0) * 10.0).round() / 10.0)
+        }
+        _ => None,
+    }
+}
+
+fn ballot_measure_status_name(status: db::BallotMeasureStatus) -> &'static str {
+    match status {
+        db::BallotMeasureStatus::Introduced => "introduced",
+        db::BallotMeasureStatus::InConsideration => "in_consideration",
+        db::BallotMeasureStatus::Proposed => "proposed",
+        db::BallotMeasureStatus::GatheringSignatures => "gathering_signatures",
+        db::BallotMeasureStatus::OnTheBallot => "on_the_ballot",
+        db::BallotMeasureStatus::BecameLaw => "became_law",
+        db::BallotMeasureStatus::Failed => "failed",
+        db::BallotMeasureStatus::Unknown => "unknown",
+    }
+}
+
+fn parse_ballot_measure_status(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "introduced" => Some("introduced"),
+        "in_consideration" => Some("in_consideration"),
+        "proposed" => Some("proposed"),
+        "gathering_signatures" => Some("gathering_signatures"),
+        "on_the_ballot" => Some("on_the_ballot"),
+        "became_law" => Some("became_law"),
+        "failed" => Some("failed"),
+        "unknown" => Some("unknown"),
+        _ => None,
+    }
+}
+
+fn map_election_error(error: sqlx::Error) -> ElectionDataError {
+    match error {
+        sqlx::Error::RowNotFound => ElectionDataError::ElectionNotFound,
+        error => log_internal(error),
+    }
+}
+
+fn map_race_error(error: sqlx::Error) -> ElectionDataError {
+    match error {
+        sqlx::Error::RowNotFound => ElectionDataError::RaceNotFound,
+        error => log_internal(error),
+    }
+}
+
+fn log_internal(error: sqlx::Error) -> ElectionDataError {
+    #[cfg(test)]
+    eprintln!("REST election data lookup failed: {error:?}");
+    tracing::error!(error = ?error, "REST election data lookup failed");
+    ElectionDataError::Internal
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct ElectionsQuery {
+    state: Option<String>,
+    year: Option<String>,
+    query: Option<String>,
+    limit: Option<String>,
+    offset: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct RacesQuery {
+    state: Option<String>,
+    race_type: Option<String>,
+    political_scope: Option<String>,
+    election_scope: Option<String>,
+    district_type: Option<String>,
+    query: Option<String>,
+    limit: Option<String>,
+    offset: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct RaceQuery {
+    endorser_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct PageQuery {
+    limit: Option<String>,
+    offset: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct BallotMeasuresQuery {
+    state: Option<String>,
+    status: Option<String>,
+    election_scope: Option<String>,
+    county: Option<String>,
+    municipality: Option<String>,
+    school_district: Option<String>,
+    limit: Option<String>,
+    offset: Option<String>,
+}
+
+pub(super) async fn list(
+    State(state): State<RestState>,
+    query: Result<Query<ElectionsQuery>, QueryRejection>,
+) -> Result<(HeaderMap, Json<Collection<ElectionResource>>), ApiError> {
+    let Query(query) = parse_query(query, ELECTIONS_ENDPOINT)?;
+    let page = parse_page(query.limit, query.offset, ELECTIONS_ENDPOINT)?;
+    let year = parse_optional_i32(query.year, "year", ELECTIONS_ENDPOINT)?;
+    if year.is_some_and(|year| !(1788..=9999).contains(&year)) {
+        return Err(ApiError::invalid_parameter(
+            "year",
+            "must be between 1788 and 9999",
+            ELECTIONS_ENDPOINT,
+        ));
+    }
+    let filters = ElectionFilters {
+        state: parse_optional_state(query.state, ELECTIONS_ENDPOINT)?,
+        year,
+        query: clean_optional(query.query),
+    };
+    let data = state
+        .elections
+        .elections(filters, page)
+        .await
+        .map_err(|error| map_lookup_error(error, None, None, ELECTIONS_ENDPOINT))?;
+    Ok(cached(data, CACHE_METADATA))
+}
+
+pub(super) async fn get_one(
+    State(state): State<RestState>,
+    Path(election_id): Path<String>,
+) -> Result<(HeaderMap, Json<Resource<ElectionResource>>), ApiError> {
+    let instance = format!("/api/v1/elections/{election_id}");
+    let election_id = parse_id(&election_id, "electionId", &instance)?;
+    let data = state
+        .elections
+        .election(election_id)
+        .await
+        .map_err(|error| map_lookup_error(error, Some(election_id), None, &instance))?;
+    Ok(cached(Resource { data }, CACHE_METADATA))
+}
+
+pub(super) async fn list_races(
+    State(state): State<RestState>,
+    Path(election_id): Path<String>,
+    query: Result<Query<RacesQuery>, QueryRejection>,
+) -> Result<(HeaderMap, Json<Collection<RaceSummaryResource>>), ApiError> {
+    let instance = format!("/api/v1/elections/{election_id}/races");
+    let election_id = parse_id(&election_id, "electionId", &instance)?;
+    let Query(query) = parse_query(query, &instance)?;
+    let page = parse_page(query.limit, query.offset, &instance)?;
+    let filters = RaceFilters {
+        state: parse_optional_state(query.state, &instance)?,
+        race_type: parse_optional_api_enum(query.race_type, "raceType", &instance)?,
+        political_scope: parse_optional_api_enum(
+            query.political_scope,
+            "politicalScope",
+            &instance,
+        )?,
+        election_scope: parse_optional_api_enum(query.election_scope, "electionScope", &instance)?,
+        district_type: parse_optional_api_enum(query.district_type, "districtType", &instance)?,
+        query: clean_optional(query.query),
+    };
+    let data = state
+        .elections
+        .races(election_id, filters, page)
+        .await
+        .map_err(|error| map_lookup_error(error, Some(election_id), None, &instance))?;
+    Ok(cached(data, CACHE_COLLECTION))
+}
+
+pub(super) async fn get_race(
+    State(state): State<RestState>,
+    Path((election_id, race_id)): Path<(String, String)>,
+    query: Result<Query<RaceQuery>, QueryRejection>,
+) -> Result<(HeaderMap, Json<Resource<RaceDetailResource>>), ApiError> {
+    let instance = format!("/api/v1/elections/{election_id}/races/{race_id}");
+    let election_id = parse_id(&election_id, "electionId", &instance)?;
+    let race_id = parse_id(&race_id, "raceId", &instance)?;
+    let Query(query) = parse_query(query, &instance)?;
+    let endorser_id = query
+        .endorser_id
+        .map(|value| {
+            Uuid::parse_str(&value).map_err(|_| {
+                ApiError::invalid_parameter("endorserId", "must be a UUID", instance.clone())
+            })
+        })
+        .transpose()?;
+    let data = state
+        .elections
+        .race(election_id, race_id, endorser_id)
+        .await
+        .map_err(|error| map_lookup_error(error, Some(election_id), Some(race_id), &instance))?;
+    Ok(cached(Resource { data }, CACHE_COLLECTION))
+}
+
+pub(super) async fn list_results(
+    State(state): State<RestState>,
+    Path(election_id): Path<String>,
+    query: Result<Query<PageQuery>, QueryRejection>,
+) -> Result<(HeaderMap, Json<Collection<RaceResultsFeedResource>>), ApiError> {
+    let instance = format!("/api/v1/elections/{election_id}/results");
+    let election_id = parse_id(&election_id, "electionId", &instance)?;
+    let Query(query) = parse_query(query, &instance)?;
+    let page = parse_page(query.limit, query.offset, &instance)?;
+    let data = state
+        .elections
+        .results(election_id, page)
+        .await
+        .map_err(|error| map_lookup_error(error, Some(election_id), None, &instance))?;
+    Ok(cached(data, CACHE_RESULTS))
+}
+
+pub(super) async fn list_ballot_measures(
+    State(state): State<RestState>,
+    Path(election_id): Path<String>,
+    query: Result<Query<BallotMeasuresQuery>, QueryRejection>,
+) -> Result<(HeaderMap, Json<Collection<BallotMeasureResource>>), ApiError> {
+    let instance = format!("/api/v1/elections/{election_id}/ballot-measures");
+    let election_id = parse_id(&election_id, "electionId", &instance)?;
+    let Query(query) = parse_query(query, &instance)?;
+    let page = parse_page(query.limit, query.offset, &instance)?;
+    let status = query
+        .status
+        .map(|value| {
+            parse_ballot_measure_status(&value).ok_or_else(|| {
+                ApiError::invalid_parameter(
+                    "status",
+                    "must be a valid ballot-measure status",
+                    instance.clone(),
+                )
+            })
+        })
+        .transpose()?;
+    let filters = BallotMeasureFilters {
+        state: parse_optional_state(query.state, &instance)?,
+        status,
+        election_scope: parse_optional_api_enum(query.election_scope, "electionScope", &instance)?,
+        county: clean_optional(query.county),
+        municipality: clean_optional(query.municipality),
+        school_district: clean_optional(query.school_district),
+    };
+    let data = state
+        .elections
+        .ballot_measures(election_id, filters, page)
+        .await
+        .map_err(|error| map_lookup_error(error, Some(election_id), None, &instance))?;
+    Ok(cached(data, CACHE_COLLECTION))
+}
+
+fn parse_query<T>(
+    query: Result<Query<T>, QueryRejection>,
+    instance: &str,
+) -> Result<Query<T>, ApiError> {
+    query.map_err(|error| {
+        ApiError::malformed_query(
+            format!("The query string could not be parsed: {error}"),
+            instance,
+        )
+    })
+}
+
+fn parse_page(
+    limit: Option<String>,
+    offset: Option<String>,
+    instance: &str,
+) -> Result<PageRequest, ApiError> {
+    let limit = parse_usize(limit, "limit", DEFAULT_LIMIT, instance)?;
+    if !(1..=MAX_LIMIT).contains(&limit) {
+        return Err(ApiError::invalid_parameter(
+            "limit",
+            format!("must be between 1 and {MAX_LIMIT}"),
+            instance,
+        ));
+    }
+    let offset = parse_usize(offset, "offset", 0, instance)?;
+    if offset > i64::MAX as usize {
+        return Err(ApiError::invalid_parameter(
+            "offset",
+            "is too large",
+            instance,
+        ));
+    }
+    Ok(PageRequest { limit, offset })
+}
+
+fn parse_usize(
+    value: Option<String>,
+    name: &'static str,
+    default: usize,
+    instance: &str,
+) -> Result<usize, ApiError> {
+    value
+        .map(|value| {
+            value.parse::<usize>().map_err(|_| {
+                ApiError::invalid_parameter(name, "must be a non-negative integer", instance)
+            })
+        })
+        .transpose()
+        .map(|value| value.unwrap_or(default))
+}
+
+fn parse_optional_i32(
+    value: Option<String>,
+    name: &'static str,
+    instance: &str,
+) -> Result<Option<i32>, ApiError> {
+    value
+        .map(|value| {
+            value
+                .parse::<i32>()
+                .map_err(|_| ApiError::invalid_parameter(name, "must be an integer", instance))
+        })
+        .transpose()
+}
+
+fn parse_optional_state(
+    value: Option<String>,
+    instance: &str,
+) -> Result<Option<UsState>, ApiError> {
+    value
+        .map(|value| {
+            serde_json::from_value(serde_json::Value::String(value.trim().to_ascii_uppercase()))
+                .map_err(|_| {
+                    ApiError::invalid_parameter(
+                        "state",
+                        "must be a two-letter US state or territory code",
+                        instance,
+                    )
+                })
+        })
+        .transpose()
+}
+
+fn parse_optional_api_enum<T>(
+    value: Option<String>,
+    name: &'static str,
+    instance: &str,
+) -> Result<Option<T>, ApiError>
+where
+    T: DeserializeOwned,
+{
+    value
+        .map(|value| {
+            serde_json::from_value(serde_json::Value::String(value.trim().to_ascii_lowercase()))
+                .map_err(|_| {
+                    ApiError::invalid_parameter(name, "has an unsupported value", instance)
+                })
+        })
+        .transpose()
+}
+
+fn clean_optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn parse_id(value: &str, parameter: &'static str, instance: &str) -> Result<Uuid, ApiError> {
+    Uuid::parse_str(value)
+        .map_err(|_| ApiError::invalid_path_parameter(parameter, "must be a UUID", instance))
+}
+
+fn map_lookup_error(
+    error: ElectionDataError,
+    election_id: Option<Uuid>,
+    race_id: Option<Uuid>,
+    instance: &str,
+) -> ApiError {
+    match error {
+        ElectionDataError::ElectionNotFound => ApiError::resource_not_found(
+            "election",
+            election_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+            instance,
+        ),
+        ElectionDataError::RaceNotFound => ApiError::resource_not_found(
+            "race",
+            race_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+            instance,
+        ),
+        ElectionDataError::Internal => ApiError::internal(instance),
+    }
+}
+
+fn cached<T>(data: T, cache_control: HeaderValue) -> (HeaderMap, Json<T>) {
+    let mut headers = HeaderMap::new();
+    headers.insert(CACHE_CONTROL, cache_control);
+    (headers, Json(data))
+}
+
+#[cfg(test)]
+pub(super) struct UnavailableElectionDataLookup;
+
+#[cfg(test)]
+#[async_trait]
+impl ElectionDataLookup for UnavailableElectionDataLookup {
+    async fn elections(
+        &self,
+        _filters: ElectionFilters,
+        _page: PageRequest,
+    ) -> Result<Collection<ElectionResource>, ElectionDataError> {
+        Err(ElectionDataError::Internal)
+    }
+
+    async fn election(&self, _election_id: Uuid) -> Result<ElectionResource, ElectionDataError> {
+        Err(ElectionDataError::Internal)
+    }
+
+    async fn races(
+        &self,
+        _election_id: Uuid,
+        _filters: RaceFilters,
+        _page: PageRequest,
+    ) -> Result<Collection<RaceSummaryResource>, ElectionDataError> {
+        Err(ElectionDataError::Internal)
+    }
+
+    async fn race(
+        &self,
+        _election_id: Uuid,
+        _race_id: Uuid,
+        _endorser_id: Option<Uuid>,
+    ) -> Result<RaceDetailResource, ElectionDataError> {
+        Err(ElectionDataError::Internal)
+    }
+
+    async fn results(
+        &self,
+        _election_id: Uuid,
+        _page: PageRequest,
+    ) -> Result<Collection<RaceResultsFeedResource>, ElectionDataError> {
+        Err(ElectionDataError::Internal)
+    }
+
+    async fn ballot_measures(
+        &self,
+        _election_id: Uuid,
+        _filters: BallotMeasureFilters,
+        _page: PageRequest,
+    ) -> Result<Collection<BallotMeasureResource>, ElectionDataError> {
+        Err(ElectionDataError::Internal)
+    }
+}
+
+pub(super) fn endpoint_templates() -> [&'static str; 6] {
+    [
+        "/api/v1/elections",
+        "/api/v1/elections/{electionId}",
+        "/api/v1/elections/{electionId}/races",
+        "/api/v1/elections/{electionId}/races/{raceId}",
+        "/api/v1/elections/{electionId}/results",
+        "/api/v1/elections/{electionId}/ballot-measures",
+    ]
+}
+
+pub(super) type SharedElectionDataLookup = Arc<dyn ElectionDataLookup>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and reads the configured database"]
+    async fn election_data_queries_decode_the_live_database_schema() {
+        dotenv::dotenv().ok();
+        let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+        let pool = PgPool::connect(&database_url)
+            .await
+            .expect("database must be reachable");
+        let election_id = sqlx::query_scalar::<_, Uuid>(
+            r#"
+            SELECT e.id
+            FROM election e
+            WHERE EXISTS (SELECT 1 FROM race r WHERE r.election_id = e.id)
+            ORDER BY e.election_date DESC, e.id
+            LIMIT 1
+            "#,
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("an election with races must exist");
+        let lookup = DatabaseElectionDataLookup::new(pool);
+        let page = PageRequest {
+            limit: 10,
+            offset: 0,
+        };
+
+        lookup
+            .elections(ElectionFilters::default(), page)
+            .await
+            .expect("election collection should decode");
+        lookup
+            .election(election_id)
+            .await
+            .expect("election detail should decode");
+        let races = lookup
+            .races(election_id, RaceFilters::default(), page)
+            .await
+            .expect("race collection should decode");
+        lookup
+            .results(election_id, page)
+            .await
+            .expect("results feed should decode");
+        lookup
+            .ballot_measures(election_id, BallotMeasureFilters::default(), page)
+            .await
+            .expect("ballot-measure collection should decode");
+        if let Some(race) = races.data.first() {
+            lookup
+                .race(
+                    election_id,
+                    Uuid::parse_str(&race.id).expect("race ID should be a UUID"),
+                    None,
+                )
+                .await
+                .expect("race detail should decode");
+        }
+    }
+}

--- a/server/src/rest/mod.rs
+++ b/server/src/rest/mod.rs
@@ -1,4 +1,5 @@
 mod ballots;
+mod elections;
 mod error;
 mod pagination;
 mod states;
@@ -31,6 +32,7 @@ pub struct RequestId(pub String);
 struct RestState {
     states: Arc<[StateResource]>,
     ballots: Arc<dyn ballots::BallotLookup>,
+    elections: elections::SharedElectionDataLookup,
 }
 
 #[derive(Serialize)]
@@ -44,6 +46,12 @@ struct ApiIndexData {
     version: &'static str,
     health: &'static str,
     states: &'static str,
+    elections: &'static str,
+    election: &'static str,
+    election_races: &'static str,
+    election_race: &'static str,
+    election_results: &'static str,
+    election_ballot_measures: &'static str,
     ballot_by_address: &'static str,
 }
 
@@ -60,20 +68,62 @@ struct HealthData {
 }
 
 pub fn router(states: Vec<StateResource>, pool: sqlx::PgPool) -> Router {
-    router_with_ballot_lookup(states, Arc::new(ballots::DatabaseBallotLookup::new(pool)))
+    router_with_lookups(
+        states,
+        Arc::new(ballots::DatabaseBallotLookup::new(pool.clone())),
+        Arc::new(elections::DatabaseElectionDataLookup::new(pool)),
+    )
 }
 
+#[cfg(test)]
 fn router_with_ballot_lookup(
     states: Vec<StateResource>,
     ballots: Arc<dyn ballots::BallotLookup>,
 ) -> Router {
+    router_with_lookups(
+        states,
+        ballots,
+        Arc::new(elections::UnavailableElectionDataLookup),
+    )
+}
+
+fn router_with_lookups(
+    states: Vec<StateResource>,
+    ballots: Arc<dyn ballots::BallotLookup>,
+    elections: elections::SharedElectionDataLookup,
+) -> Router {
     let state = RestState {
         states: states.into(),
         ballots,
+        elections,
     };
     let v1 = Router::new()
         .route("/health", get(health).fallback(method_not_allowed))
         .route("/states", get(states::list).fallback(method_not_allowed))
+        .route(
+            "/elections",
+            get(elections::list).fallback(method_not_allowed),
+        )
+        .route(
+            "/elections/:election_id",
+            get(elections::get_one).fallback(method_not_allowed),
+        )
+        .route(
+            "/elections/:election_id/races",
+            get(elections::list_races).fallback(method_not_allowed),
+        )
+        .route(
+            "/elections/:election_id/races/:race_id",
+            get(elections::get_race).fallback(method_not_allowed),
+        )
+        .route(
+            "/elections/:election_id/results",
+            get(elections::list_results).fallback(method_not_allowed),
+        )
+        .route(
+            "/elections/:election_id/ballot-measures",
+            get(elections::list_ballot_measures).fallback(method_not_allowed),
+        )
         .route(
             "/elections/:election_id/ballot",
             post(ballots::lookup)
@@ -98,6 +148,12 @@ async fn index() -> Json<ApiIndex> {
             version: "v1",
             health: "/api/v1/health",
             states: "/api/v1/states",
+            elections: elections::endpoint_templates()[0],
+            election: elections::endpoint_templates()[1],
+            election_races: elections::endpoint_templates()[2],
+            election_race: elections::endpoint_templates()[3],
+            election_results: elections::endpoint_templates()[4],
+            election_ballot_measures: elections::endpoint_templates()[5],
             ballot_by_address: ballots::endpoint_template(),
         },
     })
@@ -211,6 +267,205 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct SuccessfulElectionDataLookup {
+        election_filters: Mutex<Option<(elections::ElectionFilters, elections::PageRequest)>>,
+        race_filters: Mutex<Option<(elections::RaceFilters, elections::PageRequest)>>,
+        measure_filters: Mutex<Option<(elections::BallotMeasureFilters, elections::PageRequest)>>,
+    }
+
+    fn test_election(election_id: uuid::Uuid) -> elections::ElectionResource {
+        elections::ElectionResource {
+            id: election_id.to_string(),
+            slug: "minnesota-2026".to_string(),
+            title: "Minnesota 2026".to_string(),
+            description: Some("A test election.".to_string()),
+            state: Some(db::State::MN),
+            municipality: None,
+            election_date: chrono::NaiveDate::from_ymd_opt(2026, 11, 3).unwrap(),
+        }
+    }
+
+    fn test_office() -> elections::OfficeSummaryResource {
+        elections::OfficeSummaryResource {
+            id: uuid::Uuid::new_v4().to_string(),
+            title: "Mayor".to_string(),
+            subtitle: Some("Minneapolis".to_string()),
+            state: Some(db::State::MN),
+            county: Some("Hennepin".to_string()),
+            municipality: Some("Minneapolis".to_string()),
+            district: None,
+            seat: None,
+            election_scope: db::ElectionScope::City,
+            district_type: Some(db::DistrictType::City),
+            political_scope: db::PoliticalScope::Local,
+        }
+    }
+
+    fn test_race_summary(
+        election_id: uuid::Uuid,
+        race_id: uuid::Uuid,
+    ) -> elections::RaceSummaryResource {
+        elections::RaceSummaryResource {
+            id: race_id.to_string(),
+            slug: "minneapolis-mayor".to_string(),
+            title: "Mayor".to_string(),
+            election_id: election_id.to_string(),
+            race_type: db::RaceType::General,
+            vote_type: db::VoteType::Plurality,
+            state: Some(db::State::MN),
+            is_special_election: false,
+            num_elect: Some(1),
+            office: test_office(),
+            party: None,
+            results: elections::ResultSummaryResource {
+                total_votes: Some(100),
+                num_precincts_reporting: Some(10),
+                total_precincts: Some(20),
+                precinct_reporting_percentage: Some(50.0),
+                winners: Vec::new(),
+            },
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[async_trait]
+    impl elections::ElectionDataLookup for SuccessfulElectionDataLookup {
+        async fn elections(
+            &self,
+            filters: elections::ElectionFilters,
+            page: elections::PageRequest,
+        ) -> Result<elections::Collection<elections::ElectionResource>, elections::ElectionDataError>
+        {
+            *self.election_filters.lock().unwrap() = Some((filters, page));
+            Ok(elections::Collection::new(
+                vec![test_election(uuid::Uuid::nil())],
+                1,
+                page,
+            ))
+        }
+
+        async fn election(
+            &self,
+            election_id: uuid::Uuid,
+        ) -> Result<elections::ElectionResource, elections::ElectionDataError> {
+            if election_id.is_nil() {
+                return Err(elections::ElectionDataError::ElectionNotFound);
+            }
+            Ok(test_election(election_id))
+        }
+
+        async fn races(
+            &self,
+            election_id: uuid::Uuid,
+            filters: elections::RaceFilters,
+            page: elections::PageRequest,
+        ) -> Result<
+            elections::Collection<elections::RaceSummaryResource>,
+            elections::ElectionDataError,
+        > {
+            *self.race_filters.lock().unwrap() = Some((filters, page));
+            Ok(elections::Collection::new(
+                vec![test_race_summary(election_id, uuid::Uuid::nil())],
+                1,
+                page,
+            ))
+        }
+
+        async fn race(
+            &self,
+            election_id: uuid::Uuid,
+            race_id: uuid::Uuid,
+            _endorser_id: Option<uuid::Uuid>,
+        ) -> Result<elections::RaceDetailResource, elections::ElectionDataError> {
+            if race_id.is_nil() {
+                return Err(elections::ElectionDataError::RaceNotFound);
+            }
+            Ok(elections::RaceDetailResource {
+                race: ballots::test_race_resource(election_id),
+                description: Some("Race detail".to_string()),
+                ballotpedia_link: None,
+                early_voting_begins_date: None,
+                official_website: None,
+                updated_at: chrono::Utc::now(),
+            })
+        }
+
+        async fn results(
+            &self,
+            _election_id: uuid::Uuid,
+            page: elections::PageRequest,
+        ) -> Result<
+            elections::Collection<elections::RaceResultsFeedResource>,
+            elections::ElectionDataError,
+        > {
+            Ok(elections::Collection::new(
+                vec![elections::RaceResultsFeedResource {
+                    race_id: uuid::Uuid::nil().to_string(),
+                    slug: "minneapolis-mayor".to_string(),
+                    title: "Mayor".to_string(),
+                    office: test_office(),
+                    total_votes: Some(100),
+                    num_precincts_reporting: Some(10),
+                    total_precincts: Some(20),
+                    precinct_reporting_percentage: Some(50.0),
+                    candidates: vec![elections::CandidateResultResource {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        slug: "candidate".to_string(),
+                        full_name: "Test Candidate".to_string(),
+                        party: None,
+                        votes: Some(60),
+                        vote_percentage: Some(60.0),
+                    }],
+                    winners: Vec::new(),
+                    updated_at: chrono::Utc::now(),
+                }],
+                1,
+                page,
+            ))
+        }
+
+        async fn ballot_measures(
+            &self,
+            election_id: uuid::Uuid,
+            filters: elections::BallotMeasureFilters,
+            page: elections::PageRequest,
+        ) -> Result<
+            elections::Collection<elections::BallotMeasureResource>,
+            elections::ElectionDataError,
+        > {
+            *self.measure_filters.lock().unwrap() = Some((filters, page));
+            Ok(elections::Collection::new(
+                vec![elections::BallotMeasureResource {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    slug: "question-one".to_string(),
+                    title: "Question One".to_string(),
+                    status: "on_the_ballot",
+                    election_id: election_id.to_string(),
+                    state: db::State::MN,
+                    county: Some("Hennepin".to_string()),
+                    municipality: Some("Minneapolis".to_string()),
+                    school_district: None,
+                    ballot_measure_code: "Question 1".to_string(),
+                    measure_type: Some("charter_amendment".to_string()),
+                    definitions: None,
+                    description: Some("A measure.".to_string()),
+                    official_summary: None,
+                    populist_summary: None,
+                    full_text_url: None,
+                    yes_votes: Some(51),
+                    no_votes: Some(49),
+                    num_precincts_reporting: Some(10),
+                    total_precincts: Some(20),
+                    election_scope: Some(db::ElectionScope::City),
+                    updated_at: chrono::Utc::now(),
+                }],
+                1,
+                page,
+            ))
+        }
+    }
+
     fn test_router() -> Router {
         router_with_ballot_lookup(
             vec![
@@ -220,6 +475,10 @@ mod tests {
             ],
             Arc::new(TestBallotLookup),
         )
+    }
+
+    fn test_router_with_elections(lookup: Arc<SuccessfulElectionDataLookup>) -> Router {
+        router_with_lookups(Vec::new(), Arc::new(TestBallotLookup), lookup)
     }
 
     async fn call(method: Method, uri: &str) -> Response {
@@ -289,6 +548,188 @@ mod tests {
                 json_body(response).await["data"]["ballotByAddress"],
                 "/api/v1/elections/{electionId}/ballot"
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn advertises_the_election_data_endpoints() {
+        let response = call(Method::GET, "/api/v1").await;
+        let data = json_body(response).await["data"].clone();
+        assert_eq!(data["elections"], "/api/v1/elections");
+        assert_eq!(data["election"], "/api/v1/elections/{electionId}");
+        assert_eq!(
+            data["electionRaces"],
+            "/api/v1/elections/{electionId}/races"
+        );
+        assert_eq!(
+            data["electionRace"],
+            "/api/v1/elections/{electionId}/races/{raceId}"
+        );
+        assert_eq!(
+            data["electionResults"],
+            "/api/v1/elections/{electionId}/results"
+        );
+        assert_eq!(
+            data["electionBallotMeasures"],
+            "/api/v1/elections/{electionId}/ballot-measures"
+        );
+    }
+
+    #[tokio::test]
+    async fn serves_election_data_routes_with_stable_caching_and_filters() {
+        let election_id = uuid::Uuid::new_v4();
+        let race_id = uuid::Uuid::new_v4();
+        let lookup = Arc::new(SuccessfulElectionDataLookup::default());
+        let cases = [
+            (
+                format!("/api/v1/elections?state=mn&year=2026&query=primary&limit=7&offset=2"),
+                "public, max-age=300, stale-while-revalidate=900",
+                "Minnesota 2026",
+            ),
+            (
+                format!("/api/v1/elections/{election_id}"),
+                "public, max-age=300, stale-while-revalidate=900",
+                "Minnesota 2026",
+            ),
+            (
+                format!(
+                    "/api/v1/elections/{election_id}/races?state=MN&raceType=general&politicalScope=local&electionScope=city&districtType=city&query=mayor&limit=8&offset=3"
+                ),
+                "public, max-age=60, stale-while-revalidate=300",
+                "Mayor",
+            ),
+            (
+                format!("/api/v1/elections/{election_id}/races/{race_id}"),
+                "public, max-age=60, stale-while-revalidate=300",
+                "Race detail",
+            ),
+            (
+                format!("/api/v1/elections/{election_id}/results?limit=9&offset=4"),
+                "public, max-age=5, stale-while-revalidate=25",
+                "Test Candidate",
+            ),
+            (
+                format!(
+                    "/api/v1/elections/{election_id}/ballot-measures?state=mn&status=on_the_ballot&electionScope=city&county=Hennepin&municipality=Minneapolis&schoolDistrict=1&limit=6&offset=5"
+                ),
+                "public, max-age=60, stale-while-revalidate=300",
+                "Question One",
+            ),
+        ];
+
+        for (uri, cache_control, expected) in cases {
+            let response = call_with(
+                test_router_with_elections(lookup.clone()),
+                Method::GET,
+                &uri,
+                Body::empty(),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::OK, "{uri}");
+            assert_eq!(
+                response.headers().get(CACHE_CONTROL).unwrap(),
+                cache_control,
+                "{uri}"
+            );
+            assert!(json_body(response).await.to_string().contains(expected));
+        }
+
+        let (filters, page) = lookup.election_filters.lock().unwrap().clone().unwrap();
+        assert_eq!(filters.state, Some(db::State::MN));
+        assert_eq!(filters.year, Some(2026));
+        assert_eq!(filters.query.as_deref(), Some("primary"));
+        assert_eq!(
+            page,
+            elections::PageRequest {
+                limit: 7,
+                offset: 2
+            }
+        );
+
+        let (filters, page) = lookup.race_filters.lock().unwrap().clone().unwrap();
+        assert_eq!(filters.state, Some(db::State::MN));
+        assert_eq!(filters.race_type, Some(db::RaceType::General));
+        assert_eq!(filters.political_scope, Some(db::PoliticalScope::Local));
+        assert_eq!(filters.election_scope, Some(db::ElectionScope::City));
+        assert_eq!(filters.district_type, Some(db::DistrictType::City));
+        assert_eq!(filters.query.as_deref(), Some("mayor"));
+        assert_eq!(
+            page,
+            elections::PageRequest {
+                limit: 8,
+                offset: 3
+            }
+        );
+
+        let (filters, page) = lookup.measure_filters.lock().unwrap().clone().unwrap();
+        assert_eq!(filters.state, Some(db::State::MN));
+        assert_eq!(filters.status, Some("on_the_ballot"));
+        assert_eq!(filters.election_scope, Some(db::ElectionScope::City));
+        assert_eq!(filters.county.as_deref(), Some("Hennepin"));
+        assert_eq!(filters.municipality.as_deref(), Some("Minneapolis"));
+        assert_eq!(filters.school_district.as_deref(), Some("1"));
+        assert_eq!(
+            page,
+            elections::PageRequest {
+                limit: 6,
+                offset: 5
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_election_data_parameters_without_calling_the_lookup() {
+        let election_id = uuid::Uuid::new_v4();
+        for uri in [
+            "/api/v1/elections?year=1700",
+            "/api/v1/elections?state=not-a-state",
+            "/api/v1/elections?unexpected=true",
+            "/api/v1/elections/not-a-uuid",
+            &format!("/api/v1/elections/{election_id}/races?raceType=runoff"),
+            &format!("/api/v1/elections/{election_id}/results?limit=101"),
+            &format!("/api/v1/elections/{election_id}/ballot-measures?status=not-a-status"),
+        ] {
+            let response = call_with(
+                test_router_with_elections(Arc::new(SuccessfulElectionDataLookup::default())),
+                Method::GET,
+                uri,
+                Body::empty(),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+            assert_eq!(response.headers().get(CACHE_CONTROL).unwrap(), "no-store");
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_missing_elections_and_nested_races_to_stable_not_found_problems() {
+        let lookup = Arc::new(SuccessfulElectionDataLookup::default());
+        for (uri, resource) in [
+            (
+                format!("/api/v1/elections/{}", uuid::Uuid::nil()),
+                "election",
+            ),
+            (
+                format!(
+                    "/api/v1/elections/{}/races/{}",
+                    uuid::Uuid::new_v4(),
+                    uuid::Uuid::nil()
+                ),
+                "race",
+            ),
+        ] {
+            let response = call_with(
+                test_router_with_elections(lookup.clone()),
+                Method::GET,
+                &uri,
+                Body::empty(),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            assert_eq!(response.headers().get(CACHE_CONTROL).unwrap(), "no-store");
+            let body = json_body(response).await;
+            assert_eq!(body["code"], "resource_not_found");
+            assert!(body["detail"].as_str().unwrap().contains(resource));
         }
     }
 


### PR DESCRIPTION
## Summary
- batch the existing address-ballot data assembly and add supporting spatial indexes
- add focused election, race, results, and ballot-measure REST endpoints
- add endpoint-specific caching, stable pagination/errors, OpenAPI contracts, and tests

## Validation
- cargo fmt --all -- --check
- cargo check -p server
- cargo test -p server --no-fail-fast (23 passed, 4 ignored)
- cargo clippy -p server --all-targets --no-deps -- -D warnings
- read-only live database query/decode test
- OpenAPI operation validation

## Deployment
Seven index migrations must be applied to staging before deploying.