### PR TITLE
Self-service API keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
 name = "auth"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "config",
  "db",
@@ -449,6 +450,8 @@ dependencies = [
  "rand",
  "regex",
  "serde",
+ "sha2 0.10.8",
+ "sqlx",
  "thiserror 1.0.64",
  "uuid",
 ]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ To start the api server, run `cargo watch -x run` which will type check, compile
 
 To run certain mutations and queries which require staff or superuser permissions, you can add an `Authorization` token to the HTTP headers section of the playground. You can login to `https://staging.populist.us` or `https://populist.us` and grab the value from the `access_token` cookie in your browsers developer tools. Add this to the http headers like so: `"Authorization" : "Bearer <TOKEN>"`
 
+Confirmed registered users can also create durable API keys from their profile.
+The same `Authorization: Bearer pop_...` credential is resolved for GraphQL and
+REST requests. Implementation details, security properties, and the deployment
+checklist are documented in [`docs/api-keys.md`](docs/api-keys.md).
+
 ### REST API
 
 Versioned REST endpoints are available under `/api/v1`. The API index is at

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -15,3 +15,6 @@ uuid = "1.1.2"
 passwords = "3.1.8"
 rand = "0.8.5"
 regex = "1.5.6"
+base64 = "0.22.1"
+sha2 = "0.10.8"
+sqlx = { version = "0.8.3", features = ["postgres"] }

--- a/auth/src/api_key.rs
+++ b/auth/src/api_key.rs
@@ -1,0 +1,114 @@
+use crate::AccessTokenClaims;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use db::{ApiKey, User};
+use jsonwebtoken::{Header, TokenData};
+use rand::{rngs::OsRng, RngCore};
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+
+pub const API_KEY_PREFIX: &str = "pop_";
+const SECRET_BYTES: usize = 32;
+const DISPLAY_SECRET_CHARS: usize = 8;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AuthenticationKind {
+    Jwt,
+    ApiKey,
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestAuthentication {
+    pub claims: AccessTokenClaims,
+    pub kind: AuthenticationKind,
+}
+
+#[derive(Debug)]
+pub struct GeneratedApiKey {
+    pub plaintext: String,
+    pub display_prefix: String,
+    pub hash: [u8; 32],
+}
+
+pub fn generate_api_key() -> GeneratedApiKey {
+    let mut secret = [0_u8; SECRET_BYTES];
+    OsRng.fill_bytes(&mut secret);
+    let encoded = URL_SAFE_NO_PAD.encode(secret);
+    let plaintext = format!("{API_KEY_PREFIX}{encoded}");
+    let display_prefix = format!("{API_KEY_PREFIX}{}", &encoded[..DISPLAY_SECRET_CHARS]);
+    let hash = hash_api_key(&plaintext);
+
+    GeneratedApiKey {
+        plaintext,
+        display_prefix,
+        hash,
+    }
+}
+
+pub fn hash_api_key(api_key: &str) -> [u8; 32] {
+    Sha256::digest(api_key.as_bytes()).into()
+}
+
+pub async fn authenticate_api_key(
+    pool: &PgPool,
+    api_key: &str,
+) -> Result<Option<TokenData<AccessTokenClaims>>, db::Error> {
+    if !api_key.starts_with(API_KEY_PREFIX) {
+        return Ok(None);
+    }
+
+    let Some(key) = ApiKey::find_active_by_hash(pool, &hash_api_key(api_key)).await? else {
+        return Ok(None);
+    };
+    let user = User::find_by_id(pool, key.user_id).await?;
+    if user.confirmed_at.is_none() {
+        return Ok(None);
+    }
+    let organizations = User::organization_roles(pool, user.id).await?;
+    let claims = AccessTokenClaims {
+        sub: user.id,
+        username: user.username,
+        email: user.email,
+        system_role: user.system_role,
+        organizations,
+        // API keys do not expire here. The claim only lives for this request.
+        exp: usize::MAX,
+    };
+
+    ApiKey::mark_used(pool, key.id).await?;
+
+    Ok(Some(TokenData {
+        header: Header::default(),
+        claims,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_keys_are_unique_and_safe_to_display() {
+        let first = generate_api_key();
+        let second = generate_api_key();
+
+        assert!(first.plaintext.starts_with(API_KEY_PREFIX));
+        assert_eq!(first.plaintext.len(), API_KEY_PREFIX.len() + 43);
+        assert_eq!(
+            first.display_prefix.len(),
+            API_KEY_PREFIX.len() + DISPLAY_SECRET_CHARS
+        );
+        assert!(first.plaintext.starts_with(&first.display_prefix));
+        assert_eq!(first.hash, hash_api_key(&first.plaintext));
+        assert_ne!(first.plaintext, second.plaintext);
+        assert_ne!(first.hash, second.hash);
+    }
+
+    #[test]
+    fn hashing_is_deterministic_without_revealing_the_key() {
+        let key = "pop_example";
+        let hash = hash_api_key(key);
+
+        assert_eq!(hash, hash_api_key(key));
+        assert_ne!(hash.as_slice(), key.as_bytes());
+    }
+}

--- a/auth/src/jwt.rs
+++ b/auth/src/jwt.rs
@@ -5,7 +5,7 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccessTokenClaims {
     pub sub: uuid::Uuid,
     pub username: String,

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod api_key;
 pub mod errors;
 pub mod jwt;
+pub use api_key::*;
 pub use errors::Error;
 pub use jwt::*;
 pub use passwords::PasswordGenerator;

--- a/db/migrations/20260805120000_CreateUserApiKeys.down.sql
+++ b/db/migrations/20260805120000_CreateUserApiKeys.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_api_key;

--- a/db/migrations/20260805120000_CreateUserApiKeys.up.sql
+++ b/db/migrations/20260805120000_CreateUserApiKeys.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE user_api_key (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES populist_user(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL CHECK (length(BTRIM(name)) > 0),
+    key_prefix VARCHAR(16) NOT NULL,
+    key_hash BYTEA NOT NULL UNIQUE CHECK (octet_length(key_hash) = 32),
+    last_used_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX user_api_key_active_name_idx
+    ON user_api_key (user_id, LOWER(name))
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX user_api_key_active_hash_idx
+    ON user_api_key (key_hash)
+    WHERE revoked_at IS NULL;

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -10,6 +10,7 @@ pub type DateTime = chrono::DateTime<chrono::Utc>;
 pub use errors::Error;
 
 pub use models::address::*;
+pub use models::api_key::*;
 pub use models::argument::*;
 pub use models::ballot_measure::*;
 pub use models::bill::*;

--- a/db/src/models/api_key.rs
+++ b/db/src/models/api_key.rs
@@ -1,0 +1,162 @@
+use crate::DateTime;
+use sqlx::{FromRow, PgPool};
+use uuid::Uuid;
+
+pub const MAX_ACTIVE_API_KEYS: i64 = 10;
+
+#[derive(Debug, Clone, FromRow)]
+pub struct ApiKey {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub name: String,
+    pub key_prefix: String,
+    pub last_used_at: Option<DateTime>,
+    pub revoked_at: Option<DateTime>,
+    pub created_at: DateTime,
+    pub updated_at: DateTime,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ApiKeyError {
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+
+    #[error("API keys can only be created for confirmed users")]
+    UserNotConfirmed,
+
+    #[error("You can have at most {MAX_ACTIVE_API_KEYS} active API keys")]
+    ActiveKeyLimit,
+
+    #[error("An active API key with this name already exists")]
+    DuplicateName,
+}
+
+impl ApiKey {
+    pub async fn create(
+        pool: &PgPool,
+        user_id: Uuid,
+        name: &str,
+        key_prefix: &str,
+        key_hash: &[u8],
+    ) -> Result<Self, ApiKeyError> {
+        let mut transaction = pool.begin().await?;
+
+        // Lock the user row so concurrent key creation cannot bypass the per-user limit.
+        let confirmed_at = sqlx::query_scalar::<_, Option<DateTime>>(
+            "SELECT confirmed_at FROM populist_user WHERE id = $1 FOR UPDATE",
+        )
+        .bind(user_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .flatten();
+
+        if confirmed_at.is_none() {
+            return Err(ApiKeyError::UserNotConfirmed);
+        }
+
+        let active_count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM user_api_key WHERE user_id = $1 AND revoked_at IS NULL",
+        )
+        .bind(user_id)
+        .fetch_one(&mut *transaction)
+        .await?;
+
+        if active_count >= MAX_ACTIVE_API_KEYS {
+            return Err(ApiKeyError::ActiveKeyLimit);
+        }
+
+        let key = sqlx::query_as::<_, Self>(
+            r#"
+            INSERT INTO user_api_key (user_id, name, key_prefix, key_hash)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, user_id, name, key_prefix, last_used_at, revoked_at,
+                      created_at, updated_at
+            "#,
+        )
+        .bind(user_id)
+        .bind(name)
+        .bind(key_prefix)
+        .bind(key_hash)
+        .fetch_one(&mut *transaction)
+        .await
+        .map_err(|error| match &error {
+            sqlx::Error::Database(database_error)
+                if database_error.constraint() == Some("user_api_key_active_name_idx") =>
+            {
+                ApiKeyError::DuplicateName
+            }
+            _ => ApiKeyError::Database(error),
+        })?;
+
+        transaction.commit().await?;
+        Ok(key)
+    }
+
+    pub async fn list_active(pool: &PgPool, user_id: Uuid) -> Result<Vec<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT id, user_id, name, key_prefix, last_used_at, revoked_at,
+                   created_at, updated_at
+            FROM user_api_key
+            WHERE user_id = $1 AND revoked_at IS NULL
+            ORDER BY created_at DESC
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn find_active_by_hash(
+        pool: &PgPool,
+        key_hash: &[u8],
+    ) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT id, user_id, name, key_prefix, last_used_at, revoked_at,
+                   created_at, updated_at
+            FROM user_api_key
+            WHERE key_hash = $1 AND revoked_at IS NULL
+            "#,
+        )
+        .bind(key_hash)
+        .fetch_optional(pool)
+        .await
+    }
+
+    pub async fn mark_used(pool: &PgPool, id: Uuid) -> Result<(), sqlx::Error> {
+        // Avoid a database write on every request while keeping last-used data useful.
+        sqlx::query(
+            r#"
+            UPDATE user_api_key
+            SET last_used_at = NOW(), updated_at = NOW()
+            WHERE id = $1
+              AND (last_used_at IS NULL OR last_used_at < NOW() - INTERVAL '5 minutes')
+            "#,
+        )
+        .bind(id)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn revoke(
+        pool: &PgPool,
+        user_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            UPDATE user_api_key
+            SET revoked_at = NOW(), updated_at = NOW()
+            WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
+            RETURNING id, user_id, name, key_prefix, last_used_at, revoked_at,
+                      created_at, updated_at
+            "#,
+        )
+        .bind(id)
+        .bind(user_id)
+        .fetch_optional(pool)
+        .await
+    }
+}

--- a/db/src/models/mod.rs
+++ b/db/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod address;
+pub mod api_key;
 pub mod argument;
 pub mod ballot_measure;
 pub mod bill;

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -1,0 +1,42 @@
+# Self-service API keys
+
+Registered users manage API keys from the **API keys** section of their
+profile. The profile uses these authenticated GraphQL operations:
+
+- `apiKeys` lists the current user's active keys.
+- `createApiKey(name: String!)` creates a key and returns its secret once.
+- `revokeApiKey(id: ID!)` immediately revokes a key owned by the current user.
+
+Key-management operations require an interactive access-token or cookie
+session. An API key cannot list, create, or revoke keys.
+
+## Authentication flow
+
+Keys use the `pop_` prefix followed by 32 random bytes encoded as unpadded
+base64url. The server stores a SHA-256 hash, the first eight encoded characters
+for identification, ownership, and audit timestamps. It never stores the full
+secret.
+
+The shared HTTP bearer resolver accepts either an existing access JWT or an API
+key from:
+
+```http
+Authorization: Bearer pop_...
+```
+
+After a key is resolved, the server loads its owner and current organization
+roles into the same request-local claims used by cookie and JWT authentication.
+This makes one key work across GraphQL and versioned REST routes and ensures
+permission changes apply without reissuing it. Last-use time is updated at most
+once every five minutes to avoid a write on every API request.
+
+## Operational notes
+
+- Only confirmed users can create keys.
+- Each user may have at most 10 active keys.
+- Active key names must be unique per user, case-insensitively.
+- Revocation is immediate; revoked keys are retained for audit history but are
+  excluded from authentication and self-service lists.
+- Deleting a user cascades to all of their API keys.
+- Apply `db/migrations/20260805120000_CreateUserApiKeys.up.sql` before deploying
+  code that accepts self-service keys.

--- a/graphql/src/api_key.rs
+++ b/graphql/src/api_key.rs
@@ -1,0 +1,23 @@
+use async_graphql::Context;
+use auth::{AccessTokenClaims, AuthenticationKind};
+use jsonwebtoken::TokenData;
+use uuid::Uuid;
+
+use crate::types::Error;
+
+pub fn interactive_user_id(ctx: &Context<'_>) -> Result<Uuid, Error> {
+    let authentication_kind = ctx
+        .data_opt::<Option<AuthenticationKind>>()
+        .copied()
+        .flatten();
+
+    if authentication_kind == Some(AuthenticationKind::ApiKey) {
+        return Err(Error::InteractiveAuthenticationRequired);
+    }
+
+    ctx.data::<Option<TokenData<AccessTokenClaims>>>()
+        .ok()
+        .and_then(Option::as_ref)
+        .map(|token| token.claims.sub)
+        .ok_or(Error::Unauthorized)
+}

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 
+mod api_key;
 pub mod cache;
 pub mod context;
 pub mod guard;

--- a/graphql/src/mutation/api_key.rs
+++ b/graphql/src/mutation/api_key.rs
@@ -1,0 +1,55 @@
+use crate::{
+    api_key::interactive_user_id,
+    context::ApiContext,
+    types::{CreatedApiKeyResult, Error},
+};
+use async_graphql::{Context, Object, Result, ID};
+use auth::generate_api_key;
+use db::ApiKey;
+
+#[derive(Default)]
+pub struct ApiKeyMutation;
+
+#[Object]
+impl ApiKeyMutation {
+    /// Creates an API key for the current registered user.
+    /// The secret is returned once and only its hash is stored.
+    async fn create_api_key(
+        &self,
+        ctx: &Context<'_>,
+        name: String,
+    ) -> Result<CreatedApiKeyResult, Error> {
+        let user_id = interactive_user_id(ctx)?;
+        let name = name.trim();
+        if name.is_empty() || name.chars().count() > 100 {
+            return Err(Error::BadInput {
+                field: "name".to_string(),
+                message: "API key names must contain between 1 and 100 characters".to_string(),
+            });
+        }
+
+        let generated = generate_api_key();
+        let pool = &ctx.data::<ApiContext>().unwrap().pool;
+        let api_key = ApiKey::create(
+            pool,
+            user_id,
+            name,
+            &generated.display_prefix,
+            &generated.hash,
+        )
+        .await?;
+
+        Ok(CreatedApiKeyResult {
+            api_key: api_key.into(),
+            key: generated.plaintext,
+        })
+    }
+
+    /// Immediately revokes an API key owned by the current registered user.
+    async fn revoke_api_key(&self, ctx: &Context<'_>, id: ID) -> Result<bool, Error> {
+        let user_id = interactive_user_id(ctx)?;
+        let id = uuid::Uuid::parse_str(id.as_str())?;
+        let pool = &ctx.data::<ApiContext>().unwrap().pool;
+        Ok(ApiKey::revoke(pool, user_id, id).await?.is_some())
+    }
+}

--- a/graphql/src/mutation/mod.rs
+++ b/graphql/src/mutation/mod.rs
@@ -1,3 +1,4 @@
+mod api_key;
 mod argument;
 mod auth;
 mod ballot_measure;

--- a/graphql/src/mutation/mutation.rs
+++ b/graphql/src/mutation/mutation.rs
@@ -1,4 +1,5 @@
 use super::{
+    api_key::ApiKeyMutation,
     argument::ArgumentMutation,
     auth::AuthMutation,
     ballot_measure::BallotMeasureMutation,
@@ -23,6 +24,7 @@ use async_graphql::MergedObject;
 // Hide all mutations unless the user is an admin
 #[graphql(visible = "is_admin")]
 pub struct Mutation(
+    ApiKeyMutation,
     ArgumentMutation,
     ConversationMutation,
     PoliticianMutation,

--- a/graphql/src/query/api_key.rs
+++ b/graphql/src/query/api_key.rs
@@ -1,0 +1,24 @@
+use crate::{
+    api_key::interactive_user_id,
+    context::ApiContext,
+    types::{ApiKeyResult, Error},
+};
+use async_graphql::{Context, Object, Result};
+use db::ApiKey;
+
+#[derive(Default)]
+pub struct ApiKeyQuery;
+
+#[Object]
+impl ApiKeyQuery {
+    /// Lists active API keys owned by the current registered user.
+    async fn api_keys(&self, ctx: &Context<'_>) -> Result<Vec<ApiKeyResult>, Error> {
+        let user_id = interactive_user_id(ctx)?;
+        let pool = &ctx.data::<ApiContext>().unwrap().pool;
+        Ok(ApiKey::list_active(pool, user_id)
+            .await?
+            .into_iter()
+            .map(ApiKeyResult::from)
+            .collect())
+    }
+}

--- a/graphql/src/query/auth.rs
+++ b/graphql/src/query/auth.rs
@@ -77,7 +77,7 @@ impl AuthQuery {
         }
     }
 
-    /// Provides current user based on JWT found in client's access_token cookie
+    /// Provides the current user for an authenticated cookie, JWT, or API key.
     #[graphql(visible = "is_admin")]
     async fn current_user(&self, ctx: &Context<'_>) -> Result<Option<AuthTokenResult>, Error> {
         let user = ctx.data::<Option<TokenData<AccessTokenClaims>>>().unwrap();

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,4 +1,5 @@
 mod admin;
+mod api_key;
 mod auth;
 mod ballot_measure;
 mod bill;

--- a/graphql/src/query/query.rs
+++ b/graphql/src/query/query.rs
@@ -2,6 +2,7 @@ use async_graphql::{MergedObject, Object};
 
 use super::{
     admin::AdminQuery,
+    api_key::ApiKeyQuery,
     auth::AuthQuery,
     ballot_measure::BallotMeasureQuery,
     bill::BillQuery,
@@ -34,6 +35,7 @@ impl HealthQuery {
 #[derive(MergedObject, Default)]
 pub struct Query(
     AdminQuery,
+    ApiKeyQuery,
     BallotMeasureQuery,
     BillQuery,
     CandidateGuideQuery,

--- a/graphql/src/tests/api_key.rs
+++ b/graphql/src/tests/api_key.rs
@@ -1,0 +1,107 @@
+#[cfg(test)]
+mod tests {
+    use crate::{new_schema, tests::harness::TestHarness};
+    use async_graphql::Variables;
+    use auth::{AccessTokenClaims, AuthenticationKind};
+    use jsonwebtoken::{Header, TokenData};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn user_can_create_use_list_and_revoke_an_api_key() -> anyhow::Result<()> {
+        let harness = TestHarness::new().await?;
+        let user_id = harness.create_user("api-user@example.com", None).await?;
+        sqlx::query("UPDATE populist_user SET confirmed_at = NOW() WHERE id = $1")
+            .bind(user_id)
+            .execute(&harness.pool)
+            .await?;
+
+        let created: serde_json::Value = harness
+            .execute_query(
+                r#"
+                mutation CreateApiKey($name: String!) {
+                  createApiKey(name: $name) {
+                    key
+                    apiKey { id name prefix createdAt lastUsedAt }
+                  }
+                }
+                "#,
+                Some(Variables::from_json(json!({ "name": "Local development" }))),
+                Some(user_id),
+                None,
+            )
+            .await?;
+
+        let plaintext = created["createApiKey"]["key"]
+            .as_str()
+            .expect("new key is returned once");
+        let key_id = created["createApiKey"]["apiKey"]["id"]
+            .as_str()
+            .expect("key has an ID");
+        assert!(plaintext.starts_with(auth::API_KEY_PREFIX));
+        assert!(plaintext.starts_with(
+            created["createApiKey"]["apiKey"]["prefix"]
+                .as_str()
+                .expect("key has a display prefix")
+        ));
+
+        let authentication = auth::authenticate_api_key(&harness.pool, plaintext)
+            .await?
+            .expect("the new key authenticates");
+        assert_eq!(authentication.claims.sub, user_id);
+
+        let listed: serde_json::Value = harness
+            .execute_query(
+                "query ApiKeys { apiKeys { id name prefix } }",
+                None,
+                Some(user_id),
+                None,
+            )
+            .await?;
+        assert_eq!(listed["apiKeys"].as_array().unwrap().len(), 1);
+        assert_eq!(listed["apiKeys"][0]["name"], "Local development");
+
+        let revoked: serde_json::Value = harness
+            .execute_query(
+                "mutation RevokeApiKey($id: ID!) { revokeApiKey(id: $id) }",
+                Some(Variables::from_json(json!({ "id": key_id }))),
+                Some(user_id),
+                None,
+            )
+            .await?;
+        assert_eq!(revoked["revokeApiKey"], true);
+        assert!(auth::authenticate_api_key(&harness.pool, plaintext)
+            .await?
+            .is_none());
+
+        harness.cleanup().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn api_key_cannot_create_another_api_key() {
+        let claims = AccessTokenClaims {
+            sub: uuid::Uuid::new_v4(),
+            username: "api-user".to_string(),
+            email: "api-user@example.com".to_string(),
+            system_role: db::SystemRoleType::User,
+            organizations: vec![],
+            exp: usize::MAX,
+        };
+        let schema = new_schema()
+            .data(Some(TokenData {
+                header: Header::default(),
+                claims,
+            }))
+            .data(Some(AuthenticationKind::ApiKey))
+            .finish();
+
+        let response = schema
+            .execute(r#"mutation { createApiKey(name: "persistence") { key } }"#)
+            .await;
+
+        assert_eq!(response.errors.len(), 1);
+        assert!(response.errors[0]
+            .message
+            .contains("interactive signed-in session"));
+    }
+}

--- a/graphql/src/tests/mod.rs
+++ b/graphql/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod api_key;
 mod auth;
 mod conversation;
 mod harness;

--- a/graphql/src/types/api_key.rs
+++ b/graphql/src/types/api_key.rs
@@ -1,0 +1,30 @@
+use async_graphql::{SimpleObject, ID};
+use db::ApiKey;
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct ApiKeyResult {
+    pub id: ID,
+    pub name: String,
+    pub prefix: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub last_used_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl From<ApiKey> for ApiKeyResult {
+    fn from(key: ApiKey) -> Self {
+        Self {
+            id: key.id.into(),
+            name: key.name,
+            prefix: key.key_prefix,
+            created_at: key.created_at,
+            last_used_at: key.last_used_at,
+        }
+    }
+}
+
+#[derive(Debug, SimpleObject)]
+pub struct CreatedApiKeyResult {
+    pub api_key: ApiKeyResult,
+    /// The secret is returned only once and cannot be recovered later.
+    pub key: String,
+}

--- a/graphql/src/types/errors.rs
+++ b/graphql/src/types/errors.rs
@@ -13,6 +13,9 @@ pub enum Error {
     DatabaseError(#[from] db::Error),
 
     #[error(transparent)]
+    ApiKeyError(#[from] db::ApiKeyError),
+
+    #[error(transparent)]
     SqlxError(#[from] sqlx::Error),
 
     #[error("BadInput (field: {field:?}, reason: {message:?})")]
@@ -51,6 +54,9 @@ pub enum Error {
     #[error("No user authentication token was provided with request")]
     Unauthorized,
 
+    #[error("API keys must be managed from an interactive signed-in session")]
+    InteractiveAuthenticationRequired,
+
     #[error("Your email address could not be confirmed")]
     ConfirmationError,
 
@@ -77,6 +83,17 @@ impl ErrorExtensions for Error {
                 e.set("code", "BAD_USER_INPUT");
                 e.set("field", field.as_str());
                 e.set("message", message.as_str());
+            }
+            Error::ApiKeyError(
+                error @ (db::ApiKeyError::UserNotConfirmed
+                | db::ApiKeyError::ActiveKeyLimit
+                | db::ApiKeyError::DuplicateName),
+            ) => {
+                e.set("code", "BAD_USER_INPUT");
+                e.set("message", error.to_string());
+            }
+            Error::Unauthorized | Error::InteractiveAuthenticationRequired => {
+                e.set("code", "UNAUTHORIZED");
             }
             _error => {
                 e.set("code", "INTERNAL_SERVER_ERROR");

--- a/graphql/src/types/mod.rs
+++ b/graphql/src/types/mod.rs
@@ -1,4 +1,5 @@
 mod address;
+mod api_key;
 mod argument;
 mod auth;
 mod ballot_measure;
@@ -26,6 +27,7 @@ mod voting_guide;
 
 pub use self::auth::{AuthTokenResult, CreateUserResult, LoginResult};
 pub use address::{AddressExtendedMNResult, AddressResult};
+pub use api_key::{ApiKeyResult, CreatedApiKeyResult};
 pub use argument::ArgumentResult;
 pub use ballot_measure::BallotMeasureResult;
 pub use bill::BillResult;

--- a/server/src/authentication.rs
+++ b/server/src/authentication.rs
@@ -1,0 +1,57 @@
+use auth::{authenticate_api_key, jwt, AuthenticationKind, RequestAuthentication, API_KEY_PREFIX};
+use axum::{
+    extract::{Request, State},
+    http::{header::AUTHORIZATION, HeaderMap},
+    middleware::Next,
+    response::Response,
+};
+use sqlx::PgPool;
+
+pub async fn resolve_bearer_authentication(
+    pool: &PgPool,
+    headers: &HeaderMap,
+) -> Option<RequestAuthentication> {
+    let header = headers.get(AUTHORIZATION)?.to_str().ok()?;
+    let (scheme, token) = header.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    let token = token.trim();
+
+    if token.is_empty() {
+        return None;
+    }
+
+    if token.starts_with(API_KEY_PREFIX) {
+        return match authenticate_api_key(pool, token).await {
+            Ok(Some(token_data)) => Some(RequestAuthentication {
+                claims: token_data.claims,
+                kind: AuthenticationKind::ApiKey,
+            }),
+            Ok(None) => None,
+            Err(error) => {
+                tracing::error!(error = %error, "API key authentication failed");
+                None
+            }
+        };
+    }
+
+    jwt::validate_access_token(token)
+        .ok()
+        .map(|token_data| RequestAuthentication {
+            claims: token_data.claims,
+            kind: AuthenticationKind::Jwt,
+        })
+}
+
+pub async fn authentication_middleware(
+    State(pool): State<PgPool>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    if let Some(authentication) = resolve_bearer_authentication(&pool, request.headers()).await {
+        request.extensions_mut().insert(authentication);
+    }
+
+    next.run(request).await
+}

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -1,13 +1,12 @@
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
-use auth::{jwt, AccessTokenClaims};
+use auth::{jwt, AccessTokenClaims, RequestAuthentication};
 use axum::{
-    extract::{ConnectInfo, State},
-    http::HeaderMap,
+    extract::{ConnectInfo, Extension, State},
     response::{self, IntoResponse},
 };
 use graphql::{PopulistSchema, SessionData, SessionID};
-use jsonwebtoken::TokenData;
+use jsonwebtoken::{Header, TokenData};
 use std::net::SocketAddr;
 use tower_cookies::{cookie::SameSite, Cookie, Cookies};
 
@@ -77,29 +76,17 @@ async fn refresh_token_check(cookies: &Cookies) -> Option<TokenData<AccessTokenC
 pub async fn graphql_handler(
     ConnectInfo(ip): ConnectInfo<SocketAddr>,
     State(schema): State<PopulistSchema>,
-    headers: HeaderMap,
     cookies: Cookies,
+    authentication: Option<Extension<RequestAuthentication>>,
     req: GraphQLRequest,
 ) -> GraphQLResponse {
-    let mut headers = headers.clone();
-    headers.insert("Access-Control-Allow-Credentials", "true".parse().unwrap());
-
-    let bearer_token = headers
-        .get("authorization")
-        .and_then(|header| header.to_str().ok())
-        .and_then(|header| header.split_whitespace().nth(1));
-
-    let bearer_token_data = if let Some(token) = bearer_token {
-        let token_data = jwt::validate_access_token(token);
-        if let Ok(token_data) = token_data {
-            tracing::debug!("{:?}", token_data);
-            Some(token_data)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    let bearer_authentication = authentication.map(|Extension(authentication)| authentication);
+    let bearer_token_data = bearer_authentication
+        .as_ref()
+        .map(|authentication| TokenData {
+            header: Header::default(),
+            claims: authentication.claims.clone(),
+        });
 
     let cookie_token_data = match cookies.get("access_token") {
         Some(access_cookie) => match jwt::validate_access_token(access_cookie.value()) {
@@ -136,7 +123,11 @@ pub async fn graphql_handler(
     let req = req.into_inner();
 
     schema
-        .execute(req.data(token_data).data(session_data))
+        .execute(
+            req.data(token_data)
+                .data(session_data)
+                .data(bearer_authentication.map(|authentication| authentication.kind)),
+        )
         .await
         .into()
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -16,6 +16,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
+mod authentication;
 mod cron;
 pub mod jobs;
 pub mod metrics;
@@ -109,6 +110,10 @@ pub async fn run() {
                 .layer(axum::middleware::from_fn(metrics_auth)),
         )
         .layer(axum::middleware::from_fn(metrics::track_metrics))
+        .layer(axum::middleware::from_fn_with_state(
+            pool.connection.clone(),
+            authentication::authentication_middleware,
+        ))
         .layer(cors_layer())
         .layer(CookieManagerLayer::new());
 


### PR DESCRIPTION
Adds secure user-managed API keys across GraphQL and REST, including hashed storage, create/list/revoke operations, authorization integration, migration, tests, and deployment documentation.

Validation:
- cargo check -p auth -p db -p graphql -p server --all-targets
- cargo test -p auth api_key
- interactive-session guard test passes
- DB lifecycle test compiles but local execution requires CREATE DATABASE permission